### PR TITLE
Changes tests to use Assert pattern.

### DIFF
--- a/Functional.Tests/Options/OptionSerializationTests.cs
+++ b/Functional.Tests/Options/OptionSerializationTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 using FluentAssertions;
-using Functional.Tests.Utilities;
 using Xunit;
 
 namespace Functional.Tests.Options

--- a/Functional.Tests/Results/ResultExtensionsTests.cs
+++ b/Functional.Tests/Results/ResultExtensionsTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using FluentAssertions;
-using Functional.Tests.Utilities.Assertions;
 using Xunit;
 
 namespace Functional.Tests.Results
@@ -12,13 +11,28 @@ namespace Functional.Tests.Results
 			public class AndMatch
 			{
 				[Fact]
-				public void ShouldMapOptionSomeToFirstValue() => Result.Success<Option<int>, string>(Option.Some(1337)).Match(First, Second, Third).Should().Be("1337");
+				public void ShouldMapOptionSomeToFirstValue() 
+					=> Result
+						.Success<Option<int>, string>(Option.Some(1337))
+						.Match(First, Second, Third)
+						.Should()
+						.Be("1337");
 
 				[Fact]
-				public void ShouldMapOptionNoneToSecondValue() => Result.Success<Option<int>, string>(Option.None<int>()).Match(First, Second, Third).Should().Be("none");
+				public void ShouldMapOptionNoneToSecondValue() 
+					=> Result
+						.Success<Option<int>, string>(Option.None<int>())
+						.Match(First, Second, Third)
+						.Should()
+						.Be("none");
 
 				[Fact]
-				public void ShouldMapOptionNoneToThirdValue() => Result.Failure<Option<int>, string>("error").Match(First, Second, Third).Should().Be("error");
+				public void ShouldMapOptionNoneToThirdValue() 
+					=> Result
+						.Failure<Option<int>, string>("error")
+						.Match(First, Second, Third)
+						.Should()
+						.Be("error");
 
 				private static string First(int i) => i.ToString();
 				private static string Second() => "none";
@@ -28,13 +42,28 @@ namespace Functional.Tests.Results
 			public class AndMatchAsync
 			{
 				[Fact]
-				public async Task ShouldMapOptionSomeToFirstValue() => (await Result.Success<Option<int>, string>(Option.Some(1337)).MatchAsync(First, Second, Third)).Should().Be("1337");
+				public Task ShouldMapOptionSomeToFirstValue() 
+					=> Result
+						.Success<Option<int>, string>(Option.Some(1337))
+						.MatchAsync(First, Second, Third)
+						.Should()
+						.Be("1337");
 
 				[Fact]
-				public async Task ShouldMapOptionNoneToSecondValue() => (await Result.Success<Option<int>, string>(Option.None<int>()).MatchAsync(First, Second, Third)).Should().Be("none");
+				public Task ShouldMapOptionNoneToSecondValue() 
+					=> Result
+						.Success<Option<int>, string>(Option.None<int>())
+						.MatchAsync(First, Second, Third)
+						.Should()
+						.Be("none");
 
 				[Fact]
-				public async Task ShouldMapOptionNoneToThirdValue() => (await Result.Failure<Option<int>, string>("error").MatchAsync(First, Second, Third)).Should().Be("error");
+				public Task ShouldMapOptionNoneToThirdValue() 
+					=> Result
+						.Failure<Option<int>, string>("error")
+						.MatchAsync(First, Second, Third)
+						.Should()
+						.Be("error");
 
 				private static Task<string> First(int i) => Task.FromResult(i.ToString());
 				private static Task<string> Second() => Task.FromResult("none");
@@ -46,13 +75,29 @@ namespace Functional.Tests.Results
 				public class OntoValueProducingFunction
 				{
 					[Fact]
-					public void ShouldMapOptionSomeToOptionSome() => Result.Success<Option<int>, string>(Option.Some(1337)).SelectIfSome(IsEven).Should().BeSuccessful(option => option.Should().HaveExpectedValue(false));
+					public void ShouldMapOptionSomeToOptionSome() 
+						=> Result
+							.Success<Option<int>, string>(Option.Some(1337))
+							.SelectIfSome(IsEven)
+							.AssertSuccess()
+							.AssertSome()
+							.Should()
+							.BeFalse();
 
 					[Fact]
-					public void ShouldMapOptionNoneToOptionNone() => Result.Success<Option<int>, string>(Option.None<int>()).SelectIfSome(IsEven).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public void ShouldMapOptionNoneToOptionNone() 
+						=> Result
+							.Success<Option<int>, string>(Option.None<int>())
+							.SelectIfSome(IsEven)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public void ShouldDoNothingOnFailure() => Result.Failure<Option<int>, string>("some error").SelectIfSome(IsEven).Should().BeFaulted();
+					public void ShouldDoNothingOnFailure() 
+						=> Result
+							.Failure<Option<int>, string>("some error")
+							.SelectIfSome(IsEven)
+							.AssertFailure();
 
 					private static bool IsEven(int i) => i % 2 == 0;
 				}
@@ -62,13 +107,29 @@ namespace Functional.Tests.Results
 					public class OfSome
 					{
 						[Fact]
-						public void ShouldMapOptionSomeToOptionSome() => Result.Success<Option<int>, string>(Option.Some(1337)).SelectIfSome(IsEven).Should().BeSuccessful(option => option.Should().HaveExpectedValue(false));
+						public void ShouldMapOptionSomeToOptionSome() 
+							=> Result
+								.Success<Option<int>, string>(Option.Some(1337))
+								.SelectIfSome(IsEven)
+								.AssertSuccess()
+								.AssertSome()
+								.Should()
+								.BeFalse();
 
 						[Fact]
-						public void ShouldMapOptionNoneToOptionNone() => Result.Success<Option<int>, string>(Option.None<int>()).SelectIfSome(IsEven).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public void ShouldMapOptionNoneToOptionNone() 
+							=> Result
+								.Success<Option<int>, string>(Option.None<int>())
+								.SelectIfSome(IsEven)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public void ShouldDoNothingOnFailure() => Result.Failure<Option<int>, string>("some error").SelectIfSome(IsEven).Should().BeFaulted();
+						public void ShouldDoNothingOnFailure() 
+							=> Result
+								.Failure<Option<int>, string>("some error")
+								.SelectIfSome(IsEven)
+								.AssertFailure();
 
 						private static Option<bool> IsEven(int i) => Option.Some(i % 2 == 0);
 					}
@@ -76,13 +137,27 @@ namespace Functional.Tests.Results
 					public class OfNone
 					{
 						[Fact]
-						public void ShouldMapOptionSomeToOptionNone() => Result.Success<Option<int>, string>(Option.Some(1337)).SelectIfSome(IsEven).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public void ShouldMapOptionSomeToOptionNone() 
+							=> Result
+								.Success<Option<int>, string>(Option.Some(1337))
+								.SelectIfSome(IsEven)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public void ShouldMapOptionNoneToOptionNone() => Result.Success<Option<int>, string>(Option.None<int>()).SelectIfSome(IsEven).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public void ShouldMapOptionNoneToOptionNone() 
+							=> Result
+								.Success<Option<int>, string>(Option.None<int>())
+								.SelectIfSome(IsEven)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public void ShouldDoNothingOnFailure() => Result.Failure<Option<int>, string>("some error").SelectIfSome(IsEven).Should().BeFaulted();
+						public void ShouldDoNothingOnFailure() 
+							=> Result
+								.Failure<Option<int>, string>("some error")
+								.SelectIfSome(IsEven)
+								.AssertFailure();
 
 						private static Option<bool> IsEven(int i) => Option.None<bool>();
 					}
@@ -94,13 +169,29 @@ namespace Functional.Tests.Results
 				public class OntoValueProducingFunction
 				{
 					[Fact]
-					public async Task ShouldMapOptionSomeToOptionSome() => (await Result.Success<Option<int>, string>(Option.Some(1337)).SelectIfSomeAsync(IsEvenAsync)).Should().BeSuccessful(option => option.Should().HaveExpectedValue(false));
+					public Task ShouldMapOptionSomeToOptionSome() 
+						=> Result
+							.Success<Option<int>, string>(Option.Some(1337))
+							.SelectIfSomeAsync(IsEvenAsync)
+							.AssertSuccess()
+							.AssertSome()
+							.Should()
+							.BeFalse();
 
 					[Fact]
-					public async Task ShouldMapOptionNoneToOptionNone() => (await Result.Success<Option<int>, string>(Option.None<int>()).SelectIfSomeAsync(IsEvenAsync)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public Task ShouldMapOptionNoneToOptionNone() 
+						=> Result
+							.Success<Option<int>, string>(Option.None<int>())
+							.SelectIfSomeAsync(IsEvenAsync)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public async Task ShouldDoNothingOnFailure() => (await Result.Failure<Option<int>, string>("some error").SelectIfSomeAsync(IsEvenAsync)).Should().BeFaulted();
+					public Task ShouldDoNothingOnFailure() 
+						=> Result
+							.Failure<Option<int>, string>("some error")
+							.SelectIfSomeAsync(IsEvenAsync)
+							.AssertFailure();
 
 					private static Task<bool> IsEvenAsync(int i) => Task.FromResult(i % 2 == 0);
 				}
@@ -110,13 +201,29 @@ namespace Functional.Tests.Results
 					public class OfSome
 					{
 						[Fact]
-						public async Task ShouldMapOptionSomeToOptionSome() => (await Result.Success<Option<int>, string>(Option.Some(1337)).SelectIfSomeAsync(IsEvenAsync)).Should().BeSuccessful(option => option.Should().HaveExpectedValue(false));
+						public Task ShouldMapOptionSomeToOptionSome() 
+							=> Result
+								.Success<Option<int>, string>(Option.Some(1337))
+								.SelectIfSomeAsync(IsEvenAsync)
+								.AssertSuccess()
+								.AssertSome()
+								.Should()
+								.BeFalse();
 
 						[Fact]
-						public async Task ShouldMapOptionNoneToOptionNone() => (await Result.Success<Option<int>, string>(Option.None<int>()).SelectIfSomeAsync(IsEvenAsync)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionNoneToOptionNone() 
+							=> Result
+								.Success<Option<int>, string>(Option.None<int>())
+								.SelectIfSomeAsync(IsEvenAsync)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldDoNothingOnFailure() => (await Result.Failure<Option<int>, string>("some error").SelectIfSomeAsync(IsEvenAsync)).Should().BeFaulted();
+						public Task ShouldDoNothingOnFailure() 
+							=> Result
+								.Failure<Option<int>, string>("some error")
+								.SelectIfSomeAsync(IsEvenAsync)
+								.AssertFailure();
 
 						private static Task<Option<bool>> IsEvenAsync(int i) => Task.FromResult(Option.Some(i % 2 == 0));
 					}
@@ -124,13 +231,27 @@ namespace Functional.Tests.Results
 					public class OfNone
 					{
 						[Fact]
-						public async Task ShouldMapOptionSomeToOptionNone() => (await Result.Success<Option<int>, string>(Option.Some(1337)).SelectIfSomeAsync(IsEvenAsync)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionSomeToOptionNone() 
+							=> Result
+								.Success<Option<int>, string>(Option.Some(1337))
+								.SelectIfSomeAsync(IsEvenAsync)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldMapOptionNoneToOptionNone() => (await Result.Success<Option<int>, string>(Option.None<int>()).SelectIfSomeAsync(IsEvenAsync)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionNoneToOptionNone() 
+							=> Result
+								.Success<Option<int>, string>(Option.None<int>())
+								.SelectIfSomeAsync(IsEvenAsync)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldDoNothingOnFailure() => (await Result.Failure<Option<int>, string>("some error").SelectIfSomeAsync(IsEvenAsync)).Should().BeFaulted();
+						public Task ShouldDoNothingOnFailure() 
+							=> Result
+								.Failure<Option<int>, string>("some error")
+								.SelectIfSomeAsync(IsEvenAsync)
+								.AssertFailure();
 
 						private static Task<Option<bool>> IsEvenAsync(int i) => Task.FromResult(Option.None<bool>());
 					}
@@ -142,13 +263,29 @@ namespace Functional.Tests.Results
 				public class AndFunctionProducesSuccessfulResult
 				{
 					[Fact]
-					public void ShouldMapOptionSomeToOptionSome() => Result.Success<Option<int>, string>(Option.Some(1337)).BindIfSome(IsEvenResult).Should().BeSuccessful(option => option.Should().HaveExpectedValue(false));
+					public void ShouldMapOptionSomeToOptionSome() 
+						=> Result
+							.Success<Option<int>, string>(Option.Some(1337))
+							.BindIfSome(IsEvenResult)
+							.AssertSuccess()
+							.AssertSome()
+							.Should()
+							.BeFalse();
 
 					[Fact]
-					public void ShouldMapOptionNoneToOptionNone() => Result.Success<Option<int>, string>(Option.None<int>()).BindIfSome(IsEvenResult).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public void ShouldMapOptionNoneToOptionNone() 
+						=> Result
+							.Success<Option<int>, string>(Option.None<int>())
+							.BindIfSome(IsEvenResult)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public void ShouldDoNothingOnFailure() => Result.Failure<Option<int>, string>("some error").BindIfSome(IsEvenResult).Should().BeFaulted();
+					public void ShouldDoNothingOnFailure() 
+						=> Result
+							.Failure<Option<int>, string>("some error")
+							.BindIfSome(IsEvenResult)
+							.AssertFailure();
 
 					private static Result<bool, string> IsEvenResult(int i) => Result.Success<bool, string>(i % 2 == 0);
 				}
@@ -156,16 +293,31 @@ namespace Functional.Tests.Results
 				public class AndFunctionProducesFaultedResult
 				{
 					[Fact]
-					public void ShouldMapOptionSomeToFaultedResult() => Result.Success<Option<int>, string>(Option.Some(1337)).BindIfSome(ErrorResult).Should().BeFaultedWithExpectedValue(ERROR);
+					public void ShouldMapOptionSomeToFaultedResult() 
+						=> Result
+							.Success<Option<int>, string>(Option.Some(1337))
+							.BindIfSome(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(ERROR);
 
 					[Fact]
-					public void ShouldMapOptionNoneToOptionNone() => Result.Success<Option<int>, string>(Option.None<int>()).BindIfSome(ErrorResult).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public void ShouldMapOptionNoneToOptionNone() 
+						=> Result
+							.Success<Option<int>, string>(Option.None<int>())
+							.BindIfSome(ErrorResult)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
 					public void ShouldDoNothingOnFailure()
 					{
 						const string EXISTING_ERROR = "something strange happened";
-						Result.Failure<Option<int>, string>(EXISTING_ERROR).BindIfSome(ErrorResult).Should().BeFaultedWithExpectedValue(EXISTING_ERROR);
+						Result.Failure<Option<int>, string>(EXISTING_ERROR)
+							.BindIfSome(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(EXISTING_ERROR);
 					}
 
 					private const string ERROR = "error";
@@ -178,13 +330,29 @@ namespace Functional.Tests.Results
 				public class AndFunctionProducesSuccessfulResult
 				{
 					[Fact]
-					public async Task ShouldMapOptionSomeToOptionSome() => (await Result.Success<Option<int>, string>(Option.Some(1337)).BindIfSomeAsync(IsEvenResultAsync)).Should().BeSuccessful(option => option.Should().HaveExpectedValue(false));
+					public Task ShouldMapOptionSomeToOptionSome() 
+						=> Result
+							.Success<Option<int>, string>(Option.Some(1337))
+							.BindIfSomeAsync(IsEvenResultAsync)
+							.AssertSuccess()
+							.AssertSome()
+							.Should()
+							.BeFalse();
 
 					[Fact]
-					public async Task ShouldMapOptionNoneToOptionNone() => (await Result.Success<Option<int>, string>(Option.None<int>()).BindIfSomeAsync(IsEvenResultAsync)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public Task ShouldMapOptionNoneToOptionNone() 
+						=> Result
+							.Success<Option<int>, string>(Option.None<int>())
+							.BindIfSomeAsync(IsEvenResultAsync)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public async Task ShouldDoNothingOnFailure() => (await Result.Failure<Option<int>, string>("some error").BindIfSomeAsync(IsEvenResultAsync)).Should().BeFaulted();
+					public Task ShouldDoNothingOnFailure() 
+						=> Result
+							.Failure<Option<int>, string>("some error")
+							.BindIfSomeAsync(IsEvenResultAsync)
+							.AssertFailure();
 
 					private static Task<Result<bool, string>> IsEvenResultAsync(int i) => Task.FromResult(Result.Success<bool, string>(i % 2 == 0));
 				}
@@ -192,16 +360,31 @@ namespace Functional.Tests.Results
 				public class AndFunctionProducesFaultedResult
 				{
 					[Fact]
-					public async Task ShouldMapOptionSomeToFaultedResult() => (await Result.Success<Option<int>, string>(Option.Some(1337)).BindIfSomeAsync(ErrorResult)).Should().BeFaultedWithExpectedValue(ERROR);
+					public Task ShouldMapOptionSomeToFaultedResult() 
+						=> Result
+							.Success<Option<int>, string>(Option.Some(1337))
+							.BindIfSomeAsync(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(ERROR);
 
 					[Fact]
-					public async Task ShouldMapOptionNoneToOptionNone() => (await Result.Success<Option<int>, string>(Option.None<int>()).BindIfSomeAsync(ErrorResult)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public Task ShouldMapOptionNoneToOptionNone() 
+						=> Result
+							.Success<Option<int>, string>(Option.None<int>())
+							.BindIfSomeAsync(ErrorResult)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public async Task ShouldDoNothingOnFailure()
+					public Task ShouldDoNothingOnFailure()
 					{
 						const string EXISTING_ERROR = "something strange happened";
-						(await Result.Failure<Option<int>, string>(EXISTING_ERROR).BindIfSomeAsync(ErrorResult)).Should().BeFaultedWithExpectedValue(EXISTING_ERROR);
+						return Result.Failure<Option<int>, string>(EXISTING_ERROR)
+							.BindIfSomeAsync(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(EXISTING_ERROR);
 					}
 
 					private const string ERROR = "error";
@@ -216,13 +399,29 @@ namespace Functional.Tests.Results
 					public class OfSome
 					{
 						[Fact]
-						public void ShouldMapOptionSomeToOptionSome() => Result.Success<Option<int>, string>(Option.Some(1337)).BindIfSome(IsEvenResult).Should().BeSuccessful(option => option.Should().HaveExpectedValue(false));
+						public void ShouldMapOptionSomeToOptionSome() 
+							=> Result
+								.Success<Option<int>, string>(Option.Some(1337))
+								.BindIfSome(IsEvenResult)
+								.AssertSuccess()
+								.AssertSome()
+								.Should()
+								.BeFalse();
 
 						[Fact]
-						public void ShouldMapOptionNoneToOptionNone() => Result.Success<Option<int>, string>(Option.None<int>()).BindIfSome(IsEvenResult).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public void ShouldMapOptionNoneToOptionNone() 
+							=> Result
+								.Success<Option<int>, string>(Option.None<int>())
+								.BindIfSome(IsEvenResult)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public void ShouldDoNothingOnFailure() => Result.Failure<Option<int>, string>("some error").BindIfSome(IsEvenResult).Should().BeFaulted();
+						public void ShouldDoNothingOnFailure() 
+							=> Result
+								.Failure<Option<int>, string>("some error")
+								.BindIfSome(IsEvenResult)
+								.AssertFailure();
 
 						private static Result<Option<bool>, string> IsEvenResult(int i) => Result.Success<Option<bool>, string>(Option.Some(i % 2 == 0));
 					}
@@ -230,13 +429,27 @@ namespace Functional.Tests.Results
 					public class OfNone
 					{
 						[Fact]
-						public void ShouldMapOptionSomeToOptionNone() => Result.Success<Option<int>, string>(Option.Some(1337)).BindIfSome(IsNoneResult).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public void ShouldMapOptionSomeToOptionNone() 
+							=> Result
+								.Success<Option<int>, string>(Option.Some(1337))
+								.BindIfSome(IsNoneResult)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public void ShouldMapOptionNoneToOptionNone() => Result.Success<Option<int>, string>(Option.None<int>()).BindIfSome(IsNoneResult).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public void ShouldMapOptionNoneToOptionNone() 
+							=> Result
+								.Success<Option<int>, string>(Option.None<int>())
+								.BindIfSome(IsNoneResult)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public void ShouldDoNothingOnFailure() => Result.Failure<Option<int>, string>("some error").BindIfSome(IsNoneResult).Should().BeFaulted();
+						public void ShouldDoNothingOnFailure() 
+							=> Result
+								.Failure<Option<int>, string>("some error")
+								.BindIfSome(IsNoneResult)
+								.AssertFailure();
 
 						private static Result<Option<bool>, string> IsNoneResult(int i) => Result.Success<Option<bool>, string>(Option.None<bool>());
 					}
@@ -245,16 +458,31 @@ namespace Functional.Tests.Results
 				public class AndFunctionProducesFaultedResult
 				{
 					[Fact]
-					public void ShouldMapOptionSomeToFaultedResult() => Result.Success<Option<int>, string>(Option.Some(1337)).BindIfSome(ErrorResult).Should().BeFaultedWithExpectedValue(ERROR);
+					public void ShouldMapOptionSomeToFaultedResult() 
+						=> Result
+							.Success<Option<int>, string>(Option.Some(1337))
+							.BindIfSome(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(ERROR);
 
 					[Fact]
-					public void ShouldMapOptionNoneToOptionNone() => Result.Success<Option<int>, string>(Option.None<int>()).BindIfSome(ErrorResult).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public void ShouldMapOptionNoneToOptionNone() 
+						=> Result
+							.Success<Option<int>, string>(Option.None<int>())
+							.BindIfSome(ErrorResult)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
 					public void ShouldDoNothingOnFailure()
 					{
 						const string EXISTING_ERROR = "something strange happened";
-						Result.Failure<Option<int>, string>(EXISTING_ERROR).BindIfSome(ErrorResult).Should().BeFaultedWithExpectedValue(EXISTING_ERROR);
+						Result.Failure<Option<int>, string>(EXISTING_ERROR)
+							.BindIfSome(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(EXISTING_ERROR);
 					}
 
 					private const string ERROR = "error";
@@ -269,13 +497,29 @@ namespace Functional.Tests.Results
 					public class OfSome
 					{
 						[Fact]
-						public async Task ShouldMapOptionSomeToOptionSome() => (await Result.Success<Option<int>, string>(Option.Some(1337)).BindIfSomeAsync(IsEvenResultAsync)).Should().BeSuccessful(option => option.Should().HaveExpectedValue(false));
+						public Task ShouldMapOptionSomeToOptionSome() 
+							=> Result
+								.Success<Option<int>, string>(Option.Some(1337))
+								.BindIfSomeAsync(IsEvenResultAsync)
+								.AssertSuccess()
+								.AssertSome()
+								.Should()
+								.BeFalse();
 
 						[Fact]
-						public async Task ShouldMapOptionNoneToOptionNone() => (await Result.Success<Option<int>, string>(Option.None<int>()).BindIfSomeAsync(IsEvenResultAsync)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionNoneToOptionNone() 
+							=> Result
+								.Success<Option<int>, string>(Option.None<int>())
+								.BindIfSomeAsync(IsEvenResultAsync)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldDoNothingOnFailure() => (await Result.Failure<Option<int>, string>("some error").BindIfSomeAsync(IsEvenResultAsync)).Should().BeFaulted();
+						public Task ShouldDoNothingOnFailure() 
+							=> Result
+								.Failure<Option<int>, string>("some error")
+								.BindIfSomeAsync(IsEvenResultAsync)
+								.AssertFailure();
 
 						private static Task<Result<Option<bool>, string>> IsEvenResultAsync(int i) => Task.FromResult(Result.Success<Option<bool>, string>(Option.Some(i % 2 == 0)));
 					}
@@ -283,13 +527,27 @@ namespace Functional.Tests.Results
 					public class OfNone
 					{
 						[Fact]
-						public async Task ShouldMapOptionSomeToOptionNone() => (await Result.Success<Option<int>, string>(Option.Some(1337)).BindIfSomeAsync(IsEvenResultAsync)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionSomeToOptionNone() 
+							=> Result
+								.Success<Option<int>, string>(Option.Some(1337))
+								.BindIfSomeAsync(IsEvenResultAsync)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldMapOptionNoneToOptionNone() => (await Result.Success<Option<int>, string>(Option.None<int>()).BindIfSomeAsync(IsEvenResultAsync)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionNoneToOptionNone() 
+							=> Result
+								.Success<Option<int>, string>(Option.None<int>())
+								.BindIfSomeAsync(IsEvenResultAsync)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldDoNothingOnFailure() => (await Result.Failure<Option<int>, string>("some error").BindIfSomeAsync(IsEvenResultAsync)).Should().BeFaulted();
+						public Task ShouldDoNothingOnFailure() 
+							=> Result
+								.Failure<Option<int>, string>("some error")
+								.BindIfSomeAsync(IsEvenResultAsync)
+								.AssertFailure();
 
 						private static Task<Result<Option<bool>, string>> IsEvenResultAsync(int i) => Task.FromResult(Result.Success<Option<bool>, string>(Option.None<bool>()));
 					}
@@ -298,16 +556,31 @@ namespace Functional.Tests.Results
 				public class AndFunctionProducesFaultedResult
 				{
 					[Fact]
-					public async Task ShouldMapOptionSomeToFaultedResult() => (await Result.Success<Option<int>, string>(Option.Some(1337)).BindIfSomeAsync(ErrorResult)).Should().BeFaultedWithExpectedValue(ERROR);
+					public Task ShouldMapOptionSomeToFaultedResult() 
+						=> Result
+							.Success<Option<int>, string>(Option.Some(1337))
+							.BindIfSomeAsync(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(ERROR);
 
 					[Fact]
-					public async Task ShouldMapOptionNoneToOptionNone() => (await Result.Success<Option<int>, string>(Option.None<int>()).BindIfSomeAsync(ErrorResult)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public Task ShouldMapOptionNoneToOptionNone() 
+						=> Result
+							.Success<Option<int>, string>(Option.None<int>())
+							.BindIfSomeAsync(ErrorResult)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public async Task ShouldDoNothingOnFailure()
+					public Task ShouldDoNothingOnFailure()
 					{
 						const string EXISTING_ERROR = "something strange happened";
-						(await Result.Failure<Option<int>, string>(EXISTING_ERROR).BindIfSomeAsync(ErrorResult)).Should().BeFaultedWithExpectedValue(EXISTING_ERROR);
+						return Result.Failure<Option<int>, string>(EXISTING_ERROR)
+							.BindIfSomeAsync(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(EXISTING_ERROR);
 					}
 
 					private const string ERROR = "error";
@@ -321,13 +594,28 @@ namespace Functional.Tests.Results
 			public class AndMatch
 			{
 				[Fact]
-				public async Task ShouldMapOptionSomeToFirstValue() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).Match(First, Second, Third)).Should().Be("1337");
+				public Task ShouldMapOptionSomeToFirstValue() 
+					=> Task
+						.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+						.Match(First, Second, Third)
+						.Should()
+						.Be("1337");
 
 				[Fact]
-				public async Task ShouldMapOptionNoneToSecondValue() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>()).Match(First, Second, Third))).Should().Be("none");
+				public Task ShouldMapOptionNoneToSecondValue() 
+					=> Task
+						.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+						.Match(First, Second, Third)
+						.Should()
+						.Be("none");
 
 				[Fact]
-				public async Task ShouldMapOptionNoneToThirdValue() => (await Task.FromResult(Result.Failure<Option<int>, string>("error").Match(First, Second, Third))).Should().Be("error");
+				public Task ShouldMapOptionNoneToThirdValue() 
+					=> Task
+						.FromResult(Result.Failure<Option<int>, string>("error"))
+						.Match(First, Second, Third)
+						.Should()
+						.Be("error");
 
 				private static string First(int i) => i.ToString();
 				private static string Second() => "none";
@@ -337,13 +625,28 @@ namespace Functional.Tests.Results
 			public class AndMatchAsync
 			{
 				[Fact]
-				public async Task ShouldMapOptionSomeToFirstValue() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).MatchAsync(First, Second, Third)).Should().Be("1337");
+				public Task ShouldMapOptionSomeToFirstValue() 
+					=> Task
+						.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+						.MatchAsync(First, Second, Third)
+						.Should()
+						.Be("1337");
 
 				[Fact]
-				public async Task ShouldMapOptionNoneToSecondValue() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).MatchAsync(First, Second, Third)).Should().Be("none");
+				public Task ShouldMapOptionNoneToSecondValue() 
+					=> Task
+						.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+						.MatchAsync(First, Second, Third)
+						.Should()
+						.Be("none");
 
 				[Fact]
-				public async Task ShouldMapOptionNoneToThirdValue() => (await Task.FromResult(Result.Failure<Option<int>, string>("error")).MatchAsync(First, Second, Third)).Should().Be("error");
+				public Task ShouldMapOptionNoneToThirdValue() 
+					=> Task
+						.FromResult(Result.Failure<Option<int>, string>("error"))
+						.MatchAsync(First, Second, Third)
+						.Should()
+						.Be("error");
 
 				private static Task<string> First(int i) => Task.FromResult(i.ToString());
 				private static Task<string> Second() => Task.FromResult("none");
@@ -355,13 +658,29 @@ namespace Functional.Tests.Results
 				public class OntoValueProducingFunction
 				{
 					[Fact]
-					public async Task ShouldMapOptionSomeToOptionSome() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).SelectIfSome(ToString)).Should().BeSuccessful(option => option.Should().HaveExpectedValue("1337"));
+					public Task ShouldMapOptionSomeToOptionSome()
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+							.SelectIfSome(ToString)
+							.AssertSuccess()
+							.AssertSome()
+							.Should()
+							.Be("1337");
 
 					[Fact]
-					public async Task ShouldMapOptionNoneToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).SelectIfSome(ToString)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public Task ShouldMapOptionNoneToOptionNone() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+							.SelectIfSome(ToString)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public async Task ShouldDoNothingOnFailure() => (await Task.FromResult(Result.Failure<Option<int>, string>("some error")).SelectIfSome(ToString)).Should().BeFaulted();
+					public Task ShouldDoNothingOnFailure() 
+						=> Task
+							.FromResult(Result.Failure<Option<int>, string>("some error"))
+							.SelectIfSome(ToString)
+							.AssertFailure();
 
 					private static string ToString(int i) => i.ToString();
 				}
@@ -371,13 +690,29 @@ namespace Functional.Tests.Results
 					public class OfSome
 					{
 						[Fact]
-						public async Task ShouldMapOptionSomeToOptionSome() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).SelectIfSome(ToString)).Should().BeSuccessful(option => option.Should().HaveExpectedValue("1337"));
+						public Task ShouldMapOptionSomeToOptionSome() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+								.SelectIfSome(ToString)
+								.AssertSuccess()
+								.AssertSome()
+								.Should()
+								.Be("1337");
 
 						[Fact]
-						public async Task ShouldMapOptionNoneToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).SelectIfSome(ToString)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionNoneToOptionNone() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+								.SelectIfSome(ToString)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldDoNothingOnFailure() => (await Task.FromResult(Result.Failure<Option<int>, string>("some error")).SelectIfSome(ToString)).Should().BeFaulted();
+						public Task ShouldDoNothingOnFailure() 
+							=> Task
+								.FromResult(Result.Failure<Option<int>, string>("some error"))
+								.SelectIfSome(ToString)
+								.AssertFailure();
 
 						private static Option<string> ToString(int i) => Option.Some(i.ToString());
 					}
@@ -385,13 +720,27 @@ namespace Functional.Tests.Results
 					public class OfNone
 					{
 						[Fact]
-						public async Task ShouldMapOptionSomeToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).SelectIfSome(ToString)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionSomeToOptionNone() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+								.SelectIfSome(ToString)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldMapOptionNoneToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).SelectIfSome(ToString)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionNoneToOptionNone() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+								.SelectIfSome(ToString)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldDoNothingOnFailure() => (await Task.FromResult(Result.Failure<Option<int>, string>("some error")).SelectIfSome(ToString)).Should().BeFaulted();
+						public Task ShouldDoNothingOnFailure()
+							=> Task
+								.FromResult(Result.Failure<Option<int>, string>("some error"))
+								.SelectIfSome(ToString)
+								.AssertFailure();
 
 						private static Option<string> ToString(int i) => Option.None<string>();
 					}
@@ -403,13 +752,29 @@ namespace Functional.Tests.Results
 				public class OntoValueProducingFunction
 				{
 					[Fact]
-					public async Task ShouldMapOptionSomeToOptionSome() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).SelectIfSomeAsync(i => Task.FromResult(i.ToString()))).Should().BeSuccessful(option => option.Should().HaveExpectedValue("1337"));
+					public Task ShouldMapOptionSomeToOptionSome() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+							.SelectIfSomeAsync(i => Task.FromResult(i.ToString()))
+							.AssertSuccess()
+							.AssertSome()
+							.Should()
+							.Be("1337");
 
 					[Fact]
-					public async Task ShouldMapOptionNoneToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).SelectIfSomeAsync(i => Task.FromResult(i.ToString()))).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public Task ShouldMapOptionNoneToOptionNone() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+							.SelectIfSomeAsync(i => Task.FromResult(i.ToString()))
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public async Task ShouldDoNothingOnFailure() => (await Task.FromResult(Result.Failure<Option<int>, string>("some error")).SelectIfSomeAsync(i => Task.FromResult(i.ToString()))).Should().BeFaulted();
+					public Task ShouldDoNothingOnFailure() 
+						=> Task
+							.FromResult(Result.Failure<Option<int>, string>("some error"))
+							.SelectIfSomeAsync(i => Task.FromResult(i.ToString()))
+							.AssertFailure();
 				}
 
 				public class OntoOptionProducingFunction
@@ -417,13 +782,29 @@ namespace Functional.Tests.Results
 					public class OfSome
 					{
 						[Fact]
-						public async Task ShouldMapOptionSomeToOptionSome() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).SelectIfSomeAsync(ToString)).Should().BeSuccessful(option => option.Should().HaveExpectedValue("1337"));
+						public Task ShouldMapOptionSomeToOptionSome() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+								.SelectIfSomeAsync(ToString)
+								.AssertSuccess()
+								.AssertSome()
+								.Should()
+								.Be("1337");
 
 						[Fact]
-						public async Task ShouldMapOptionNoneToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).SelectIfSomeAsync(ToString)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionNoneToOptionNone() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+								.SelectIfSomeAsync(ToString)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldDoNothingOnFailure() => (await Task.FromResult(Result.Failure<Option<int>, string>("some error")).SelectIfSomeAsync(ToString)).Should().BeFaulted();
+						public Task ShouldDoNothingOnFailure() 
+							=> Task
+								.FromResult(Result.Failure<Option<int>, string>("some error"))
+								.SelectIfSomeAsync(ToString)
+								.AssertFailure();
 
 						private static Task<Option<string>> ToString(int i) => Task.FromResult(Option.Some(i.ToString()));
 					}
@@ -431,13 +812,27 @@ namespace Functional.Tests.Results
 					public class OfNone
 					{
 						[Fact]
-						public async Task ShouldMapOptionSomeToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).SelectIfSomeAsync(ToString)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionSomeToOptionNone() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+								.SelectIfSomeAsync(ToString)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldMapOptionNoneToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).SelectIfSomeAsync(ToString)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionNoneToOptionNone() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+								.SelectIfSomeAsync(ToString)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldDoNothingOnFailure() => (await Task.FromResult(Result.Failure<Option<int>, string>("some error")).SelectIfSomeAsync(ToString)).Should().BeFaulted();
+						public Task ShouldDoNothingOnFailure() 
+							=> Task
+								.FromResult(Result.Failure<Option<int>, string>("some error"))
+								.SelectIfSomeAsync(ToString)
+								.AssertFailure();
 
 						private static Task<Option<string>> ToString(int i) => Task.FromResult(Option.None<string>());
 					}
@@ -449,13 +844,29 @@ namespace Functional.Tests.Results
 				public class AndFunctionProducesSuccessfulResult
 				{
 					[Fact]
-					public async Task ShouldMapOptionSomeToOptionSome() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).BindIfSome(IsEvenResult)).Should().BeSuccessful(option => option.Should().HaveExpectedValue(false));
+					public Task ShouldMapOptionSomeToOptionSome() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+							.BindIfSome(IsEvenResult)
+							.AssertSuccess()
+							.AssertSome()
+							.Should()
+							.BeFalse();
 
 					[Fact]
-					public async Task ShouldMapOptionNoneToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).BindIfSome(IsEvenResult)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public Task ShouldMapOptionNoneToOptionNone() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+							.BindIfSome(IsEvenResult)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public async Task ShouldDoNothingOnFailure() => (await Task.FromResult(Result.Failure<Option<int>, string>("some error")).BindIfSome(IsEvenResult)).Should().BeFaulted();
+					public Task ShouldDoNothingOnFailure() 
+						=> Task
+							.FromResult(Result.Failure<Option<int>, string>("some error"))
+							.BindIfSome(IsEvenResult)
+							.AssertFailure();
 
 					private static Result<bool, string> IsEvenResult(int i) => Result.Success<bool, string>(i % 2 == 0);
 				}
@@ -463,16 +874,31 @@ namespace Functional.Tests.Results
 				public class AndFunctionProducesFaultedResult
 				{
 					[Fact]
-					public async Task ShouldMapOptionSomeToFaultedResult() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).BindIfSome(ErrorResult)).Should().BeFaultedWithExpectedValue(ERROR);
+					public Task ShouldMapOptionSomeToFaultedResult() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+							.BindIfSome(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(ERROR);
 
 					[Fact]
-					public async Task ShouldMapOptionNoneToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).BindIfSome(ErrorResult)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public Task ShouldMapOptionNoneToOptionNone() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+							.BindIfSome(ErrorResult)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public async Task ShouldDoNothingOnFailure()
+					public Task ShouldDoNothingOnFailure()
 					{
 						const string EXISTING_ERROR = "something strange happened";
-						(await Task.FromResult(Result.Failure<Option<int>, string>(EXISTING_ERROR)).BindIfSome(ErrorResult)).Should().BeFaultedWithExpectedValue(EXISTING_ERROR);
+						return Task.FromResult(Result.Failure<Option<int>, string>(EXISTING_ERROR))
+							.BindIfSome(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(EXISTING_ERROR);
 					}
 
 					private const string ERROR = "error";
@@ -485,13 +911,29 @@ namespace Functional.Tests.Results
 				public class AndFunctionProducesSuccessfulResult
 				{
 					[Fact]
-					public async Task ShouldMapOptionSomeToOptionSome() => (await (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))).BindIfSomeAsync(IsEvenResultAsync)).Should().BeSuccessful(option => option.Should().HaveExpectedValue(false));
+					public Task ShouldMapOptionSomeToOptionSome() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+							.BindIfSomeAsync(IsEvenResultAsync)
+							.AssertSuccess()
+							.AssertSome()
+							.Should()
+							.BeFalse();
 
 					[Fact]
-					public async Task ShouldMapOptionNoneToOptionNone() => (await (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))).BindIfSomeAsync(IsEvenResultAsync)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public Task ShouldMapOptionNoneToOptionNone() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+							.BindIfSomeAsync(IsEvenResultAsync)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public async Task ShouldDoNothingOnFailure() => (await (await Task.FromResult(Result.Failure<Option<int>, string>("some error"))).BindIfSomeAsync(IsEvenResultAsync)).Should().BeFaulted();
+					public Task ShouldDoNothingOnFailure() 
+						=> Task
+							.FromResult(Result.Failure<Option<int>, string>("some error"))
+							.BindIfSomeAsync(IsEvenResultAsync)
+							.AssertFailure();
 
 					private static Task<Result<bool, string>> IsEvenResultAsync(int i) => Task.FromResult(Result.Success<bool, string>(i % 2 == 0));
 				}
@@ -499,16 +941,31 @@ namespace Functional.Tests.Results
 				public class AndFunctionProducesFaultedResult
 				{
 					[Fact]
-					public async Task ShouldMapOptionSomeToFaultedResult() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).BindIfSomeAsync(ErrorResult)).Should().BeFaultedWithExpectedValue(ERROR);
+					public Task ShouldMapOptionSomeToFaultedResult() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+							.BindIfSomeAsync(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(ERROR);
 
 					[Fact]
-					public async Task ShouldMapOptionNoneToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).BindIfSomeAsync(ErrorResult)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public Task ShouldMapOptionNoneToOptionNone() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+							.BindIfSomeAsync(ErrorResult)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public async Task ShouldDoNothingOnFailure()
+					public Task ShouldDoNothingOnFailure()
 					{
 						const string EXISTING_ERROR = "something strange happened";
-						(await Task.FromResult(Result.Failure<Option<int>, string>(EXISTING_ERROR)).BindIfSomeAsync(ErrorResult)).Should().BeFaultedWithExpectedValue(EXISTING_ERROR);
+						return Task.FromResult(Result.Failure<Option<int>, string>(EXISTING_ERROR))
+							.BindIfSomeAsync(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(EXISTING_ERROR);
 					}
 
 					private const string ERROR = "error";
@@ -523,13 +980,29 @@ namespace Functional.Tests.Results
 					public class OfSome
 					{
 						[Fact]
-						public async Task ShouldMapOptionSomeToOptionSome() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).BindIfSome(IsEvenResult)).Should().BeSuccessful(option => option.Should().HaveExpectedValue(false));
+						public Task ShouldMapOptionSomeToOptionSome() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+								.BindIfSome(IsEvenResult)
+								.AssertSuccess()
+								.AssertSome()
+								.Should()
+								.BeFalse();
 
 						[Fact]
-						public async Task ShouldMapOptionNoneToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).BindIfSome(IsEvenResult)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionNoneToOptionNone() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+								.BindIfSome(IsEvenResult)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldDoNothingOnFailure() => (await Task.FromResult(Result.Failure<Option<int>, string>("some error")).BindIfSome(IsEvenResult)).Should().BeFaulted();
+						public Task ShouldDoNothingOnFailure() 
+							=> Task
+								.FromResult(Result.Failure<Option<int>, string>("some error"))
+								.BindIfSome(IsEvenResult)
+								.AssertFailure();
 
 						private static Result<Option<bool>, string> IsEvenResult(int i) => Result.Success<Option<bool>, string>(Option.Some(i % 2 == 0));
 					}
@@ -537,13 +1010,27 @@ namespace Functional.Tests.Results
 					public class OfNone
 					{
 						[Fact]
-						public async Task ShouldMapOptionSomeToOptionSome() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).BindIfSome(IsNoneResult)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionSomeToOptionSome() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+								.BindIfSome(IsNoneResult)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldMapOptionNoneToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).BindIfSome(IsNoneResult)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionNoneToOptionNone() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+								.BindIfSome(IsNoneResult)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldDoNothingOnFailure() => (await Task.FromResult(Result.Failure<Option<int>, string>("some error")).BindIfSome(IsNoneResult)).Should().BeFaulted();
+						public Task ShouldDoNothingOnFailure() 
+							=> Task
+								.FromResult(Result.Failure<Option<int>, string>("some error"))
+								.BindIfSome(IsNoneResult)
+								.AssertFailure();
 
 						private static Result<Option<bool>, string> IsNoneResult(int i) => Result.Success<Option<bool>, string>(Option.None<bool>());
 					}
@@ -552,16 +1039,31 @@ namespace Functional.Tests.Results
 				public class AndFunctionProducesFaultedResult
 				{
 					[Fact]
-					public async Task ShouldMapOptionSomeToFaultedResult() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).BindIfSome(ErrorResult)).Should().BeFaultedWithExpectedValue(ERROR);
+					public Task ShouldMapOptionSomeToFaultedResult() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+							.BindIfSome(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(ERROR);
 
 					[Fact]
-					public async Task ShouldMapOptionNoneToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).BindIfSome(ErrorResult)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public Task ShouldMapOptionNoneToOptionNone() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+							.BindIfSome(ErrorResult)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public async Task ShouldDoNothingOnFailure()
+					public Task ShouldDoNothingOnFailure()
 					{
 						const string EXISTING_ERROR = "something strange happened";
-						(await Task.FromResult(Result.Failure<Option<int>, string>(EXISTING_ERROR)).BindIfSome(ErrorResult)).Should().BeFaultedWithExpectedValue(EXISTING_ERROR);
+						return Task.FromResult(Result.Failure<Option<int>, string>(EXISTING_ERROR))
+							.BindIfSome(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(EXISTING_ERROR);
 					}
 
 					private const string ERROR = "error";
@@ -576,13 +1078,29 @@ namespace Functional.Tests.Results
 					public class OfSome
 					{
 						[Fact]
-						public async Task ShouldMapOptionSomeToOptionSome() => (await (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))).BindIfSomeAsync(IsEvenResultAsync)).Should().BeSuccessful(option => option.Should().HaveExpectedValue(false));
+						public Task ShouldMapOptionSomeToOptionSome() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+								.BindIfSomeAsync(IsEvenResultAsync)
+								.AssertSuccess()
+								.AssertSome()
+								.Should()
+								.BeFalse();
 
 						[Fact]
-						public async Task ShouldMapOptionNoneToOptionNone() => (await (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))).BindIfSomeAsync(IsEvenResultAsync)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionNoneToOptionNone() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+								.BindIfSomeAsync(IsEvenResultAsync)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldDoNothingOnFailure() => (await (await Task.FromResult(Result.Failure<Option<int>, string>("some error"))).BindIfSomeAsync(IsEvenResultAsync)).Should().BeFaulted();
+						public Task ShouldDoNothingOnFailure() 
+							=> Task
+								.FromResult(Result.Failure<Option<int>, string>("some error"))
+								.BindIfSomeAsync(IsEvenResultAsync)
+								.AssertFailure();
 
 						private static Task<Result<Option<bool>, string>> IsEvenResultAsync(int i) => Task.FromResult(Result.Success<Option<bool>, string>(Option.Some(i % 2 == 0)));
 					}
@@ -590,13 +1108,27 @@ namespace Functional.Tests.Results
 					public class OfNone
 					{
 						[Fact]
-						public async Task ShouldMapOptionSomeToOptionSome() => (await (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))).BindIfSomeAsync(IsEvenResultAsync)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionSomeToOptionSome() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+								.BindIfSomeAsync(IsEvenResultAsync)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldMapOptionNoneToOptionNone() => (await (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))).BindIfSomeAsync(IsEvenResultAsync)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+						public Task ShouldMapOptionNoneToOptionNone() 
+							=> Task
+								.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+								.BindIfSomeAsync(IsEvenResultAsync)
+								.AssertSuccess()
+								.AssertNone();
 
 						[Fact]
-						public async Task ShouldDoNothingOnFailure() => (await (await Task.FromResult(Result.Failure<Option<int>, string>("some error"))).BindIfSomeAsync(IsEvenResultAsync)).Should().BeFaulted();
+						public Task ShouldDoNothingOnFailure() 
+							=> Task
+								.FromResult(Result.Failure<Option<int>, string>("some error"))
+								.BindIfSomeAsync(IsEvenResultAsync)
+								.AssertFailure();
 
 						private static Task<Result<Option<bool>, string>> IsEvenResultAsync(int i) => Task.FromResult(Result.Success<Option<bool>, string>(Option.None<bool>()));
 					}
@@ -605,16 +1137,31 @@ namespace Functional.Tests.Results
 				public class AndFunctionProducesFaultedResult
 				{
 					[Fact]
-					public async Task ShouldMapOptionSomeToFaultedResult() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).BindIfSomeAsync(ErrorResult)).Should().BeFaultedWithExpectedValue(ERROR);
+					public Task ShouldMapOptionSomeToFaultedResult() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.Some(1337)))
+							.BindIfSomeAsync(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(ERROR);
 
 					[Fact]
-					public async Task ShouldMapOptionNoneToOptionNone() => (await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).BindIfSomeAsync(ErrorResult)).Should().BeSuccessful(option => option.Should().NotHaveValue());
+					public Task ShouldMapOptionNoneToOptionNone() 
+						=> Task
+							.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+							.BindIfSomeAsync(ErrorResult)
+							.AssertSuccess()
+							.AssertNone();
 
 					[Fact]
-					public async Task ShouldDoNothingOnFailure()
+					public Task ShouldDoNothingOnFailure()
 					{
 						const string EXISTING_ERROR = "something strange happened";
-						(await Task.FromResult(Result.Failure<Option<int>, string>(EXISTING_ERROR)).BindIfSomeAsync(ErrorResult)).Should().BeFaultedWithExpectedValue(EXISTING_ERROR);
+						return Task.FromResult(Result.Failure<Option<int>, string>(EXISTING_ERROR))
+							.BindIfSomeAsync(ErrorResult)
+							.AssertFailure()
+							.Should()
+							.Be(EXISTING_ERROR);
 					}
 
 					private const string ERROR = "error";

--- a/Functional.Tests/Results/ResultSerializationTests.cs
+++ b/Functional.Tests/Results/ResultSerializationTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 using FluentAssertions;
-using Functional.Tests.Utilities;
 using Xunit;
 
 namespace Functional.Tests.Results

--- a/Functional.Tests/Results/ResultTests.cs
+++ b/Functional.Tests/Results/ResultTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Functional.Tests.Utilities.Assertions;
 using Xunit;
 
 namespace Functional.Tests.Results
@@ -69,11 +68,31 @@ namespace Functional.Tests.Results
 			var valueInput = Result.Success<int, string>(VALUE);
 			var valueExceptionInput = Result.Success<int, Exception>(VALUE);
 
-			valueInput.TrySelect(i => i.ToString(), ex => throw new InvalidOperationException()).Should().BeSuccessful(value => value.Should().Be(VALUE.ToString()));
-			valueExceptionInput.TrySelect(i => i.ToString()).Should().BeSuccessful(value => value.Should().Be(VALUE.ToString()));
+			valueInput
+				.TrySelect(i => i.ToString(), ex => throw new InvalidOperationException())
+				.AssertSuccess()
+				.Should()
+				.Be(VALUE.ToString());
 
-			(await Task.FromResult(valueInput).TrySelect(i => i.ToString(), ex => throw new InvalidOperationException())).Should().BeSuccessful(value => value.Should().Be(VALUE.ToString()));
-			(await Task.FromResult(valueExceptionInput).TrySelect(i => i.ToString())).Should().BeSuccessful(result => result.Should().Be(VALUE.ToString()));
+			valueExceptionInput
+				.TrySelect(i => i.ToString())
+				.AssertSuccess()
+				.Should()
+				.Be(VALUE.ToString());
+
+			await Task
+				.FromResult(valueInput)
+				.TrySelect(i => i.ToString(), ex => throw new InvalidOperationException())
+				.AssertSuccess()
+				.Should()
+				.Be(VALUE.ToString());
+
+			await Task
+				.FromResult(valueExceptionInput)
+				.TrySelect(i => i.ToString())
+				.AssertSuccess()
+				.Should()
+				.Be(VALUE.ToString());
 		}
 
 		[Fact]
@@ -84,11 +103,31 @@ namespace Functional.Tests.Results
 			var faultedInputHoldingMessage = Result.Failure<int, string>(ERROR);
 			var faultedInputHoldingException = Result.Failure<int, Exception>(exception);
 
-			faultedInputHoldingMessage.TrySelect<int, object, string>(o => throw new InvalidOperationException(), ex => throw new InvalidOperationException()).Should().BeFaulted(value => value.Should().Be(ERROR));
-			faultedInputHoldingException.TrySelect(i => (Value: i, Boolean: true)).Should().BeFaulted(value => value.Should().Be(exception));
+			faultedInputHoldingMessage
+				.TrySelect<int, object, string>(o => throw new InvalidOperationException(), ex => throw new InvalidOperationException())
+				.AssertFailure()
+				.Should()
+				.Be(ERROR);
 
-			(await Task.FromResult(faultedInputHoldingMessage).TrySelect<int, object, string>(o => throw new InvalidOperationException(), ex => throw new InvalidOperationException())).Should().BeFaulted(value => value.Should().Be(ERROR));
-			(await Task.FromResult(faultedInputHoldingException).TrySelect(i => (Value: i, Boolean: true))).Should().BeFaulted(value => value.Should().Be(exception));
+			faultedInputHoldingException
+				.TrySelect(i => (Value: i, Boolean: true))
+				.AssertFailure()
+				.Should()
+				.Be(exception);
+
+			await Task
+				.FromResult(faultedInputHoldingMessage)
+				.TrySelect<int, object, string>(o => throw new InvalidOperationException(), ex => throw new InvalidOperationException())
+				.AssertFailure()
+				.Should()
+				.Be(ERROR);
+
+			await Task
+				.FromResult(faultedInputHoldingException)
+				.TrySelect(i => (Value: i, Boolean: true))
+				.AssertFailure()
+				.Should()
+				.Be(exception);
 		}
 
 		[Fact]
@@ -98,11 +137,31 @@ namespace Functional.Tests.Results
 			var objectObjectInput = Result.Success<object, string>(new object());
 			var objectExceptionInput = Result.Success<object, Exception>(new object());
 
-			objectObjectInput.TrySelect<object, object, string>(s => throw exception, f => f.Message).Should().BeFaulted(value => value.Should().Be(exception.Message));
-			objectExceptionInput.TrySelect<object, object>(o => throw exception).Should().BeFaulted(value => value.Should().Be(exception));
+			objectObjectInput
+				.TrySelect<object, object, string>(s => throw exception, f => f.Message)
+				.AssertFailure()
+				.Should()
+				.Be(exception.Message);
 
-			(await Task.FromResult(objectObjectInput).TrySelect<object, object, string>(o => throw exception, ex => ex.Message)).Should().BeFaulted(value => value.Should().Be(exception.Message));
-			(await Task.FromResult(objectExceptionInput).TrySelect<object, object>(o => throw exception)).Should().BeFaulted(value => value.Should().Be(exception));
+			objectExceptionInput
+				.TrySelect<object, object>(o => throw exception)
+				.AssertFailure()
+				.Should()
+				.Be(exception);
+
+			await Task
+				.FromResult(objectObjectInput)
+				.TrySelect<object, object, string>(o => throw exception, ex => ex.Message)
+				.AssertFailure()
+				.Should()
+				.Be(exception.Message);
+
+			await Task
+				.FromResult(objectExceptionInput)
+				.TrySelect<object, object>(o => throw exception)
+				.AssertFailure()
+				.Should()
+				.Be(exception);
 		}
 	}
 }

--- a/Functional.Tests/Unions/AdhocUnionSerializationTests.cs
+++ b/Functional.Tests/Unions/AdhocUnionSerializationTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 using FluentAssertions;
-using Functional.Tests.Utilities;
 using Xunit;
 
 namespace Functional.Tests.Unions

--- a/Functional.Tests/Unions/UnionSerializationTests.cs
+++ b/Functional.Tests/Unions/UnionSerializationTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 using FluentAssertions;
-using Functional.Tests.Utilities;
 using Xunit;
 
 namespace Functional.Tests.Unions

--- a/Functional.Tests/Utilities/AsyncFluentAssertionExtensions.cs
+++ b/Functional.Tests/Utilities/AsyncFluentAssertionExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Collections;
+using FluentAssertions.Primitives;
+
+namespace Functional
+{
+	public static class AsyncFluentAssertionExtensions
+	{
+		public static async Task<ObjectAssertions> Should<T>(this Task<T> source)
+			=> (await source).Should();
+
+		public static async Task<AndConstraint<ObjectAssertions>> Be(this Task<ObjectAssertions> source, object expected)
+			=> (await source).Be(expected);
+
+		public static async Task<StringAssertions> Should(this Task<string> source)
+			=> (await source).Should();
+
+		public static async Task<AndConstraint<StringAssertions>> Be(this Task<StringAssertions> source, string expected)
+			=> (await source).Be(expected);
+
+		public static async Task<BooleanAssertions> Should(this Task<bool> source)
+			=> (await source).Should();
+
+		public static async Task<AndConstraint<BooleanAssertions>> BeTrue(this Task<BooleanAssertions> source)
+			=> (await source).BeTrue();
+
+		public static async Task<AndConstraint<BooleanAssertions>> BeFalse(this Task<BooleanAssertions> source)
+			=> (await source).BeFalse();
+
+		public static async Task<GenericCollectionAssertions<T>> Should<T>(this Task<IEnumerable<T>> source)
+			=> (await source).Should();
+
+		public static async Task<GenericCollectionAssertions<T>> Should<T>(this Task<T[]> source)
+		   => (await source).Should();
+
+		public static async Task<AndConstraint<GenericCollectionAssertions<T>>> BeEquivalentTo<T>(this Task<GenericCollectionAssertions<T>> source, params T[] expectations)
+		   => (await source).BeEquivalentTo(expectations);
+
+		public static async Task<StringCollectionAssertions> Should<T>(this Task<IEnumerable<string>> source)
+		   => (await source).Should();
+
+		public static async Task<StringCollectionAssertions> Should<T>(this Task<string[]> source)
+		   => (await source).Should();
+
+		public static async Task<AndConstraint<StringCollectionAssertions>> BeEquivalentTo(this Task<StringCollectionAssertions> source, params string[] expectations)
+		   => (await source).BeEquivalentTo(expectations);
+	}
+}

--- a/Functional.Tests/Utilities/OptionTestExtensions.cs
+++ b/Functional.Tests/Utilities/OptionTestExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Functional
+{
+	public static class OptionTestExtensions
+	{
+		public static TSome AssertSome<TSome>(this Option<TSome> option)
+			=> option.Match(s => s, () => throw new Exception("Option should be some."));
+
+		public static async Task<TSome> AssertSome<TSome>(this Task<Option<TSome>> option)
+		   => (await option).Match(s => s, () => throw new Exception("Option should be some."));
+
+		public static void AssertNone<TSome>(this Option<TSome> option)
+		   => option.Match(s => throw new Exception("Option should be none."), () => 0);
+
+		public static async Task AssertNone<TSome>(this Task<Option<TSome>> option)
+		   => (await option).Match(s => throw new Exception("Option should be none."), () => 0);
+	}
+}

--- a/Functional.Tests/Utilities/ResultTestExtensions.cs
+++ b/Functional.Tests/Utilities/ResultTestExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Functional
+{
+	public static class ResultTestExtensions
+	{
+		public static TSuccess AssertSuccess<TSuccess, TFailure>(this Result<TSuccess, TFailure> result)
+			=> result.Match(s => s, f => throw new Exception("Result should be success."));
+
+		public static async Task<TSuccess> AssertSuccess<TSuccess, TFailure>(this Task<Result<TSuccess, TFailure>> result)
+		   => (await result).Match(s => s, f => throw new Exception("Result should be success."));
+
+		public static TFailure AssertFailure<TSuccess, TFailure>(this Result<TSuccess, TFailure> result)
+		   => result.Match(s => throw new Exception("Result should be failure."), f => f);
+
+		public static async Task<TFailure> AssertFailure<TSuccess, TFailure>(this Task<Result<TSuccess, TFailure>> result)
+		   => (await result).Match(s => throw new Exception("Result should be failure."), f => f);
+	}
+}

--- a/Functional.Tests/Utilities/SerializationUtility.cs
+++ b/Functional.Tests/Utilities/SerializationUtility.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 
-namespace Functional.Tests.Utilities
+namespace Functional
 {
 	public static class SerializationUtility
 	{


### PR DESCRIPTION
This is what I was originally thinking when I suggested changes for the tests. I don't love having to write a nested lambda to assert the value inside the result/option since you almost always care about what that value is. That being said, maybe a ".Should().BeSuccessOfValue(someValue)" would be more consistent/better? Thoughts?