### PR TITLE
Add common build props, and fix warnings from IDisposableAnalyzers and Microsoft.VisualStudio.Threading.Analyzers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,29 @@
+﻿<Project>
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <!-- warning NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead. -->
+    <NoWarn>NU5125;$(NoWarn)</NoWarn>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageProjectUrl>https://github.com/JohannesMoersch/Functional</PackageProjectUrl>
+    <Authors>Johannes Moersch</Authors>
+    <PackageTags>functional</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Copyright>Copyright © 2019 Johannes Moersch</Copyright>
+    <Version>1.11.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers" Version="3.*" Condition=" '$(OS)' == 'Windows_NT' ">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <!-- <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.*">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference> -->
+    <PackageReference Include="IDisposableAnalyzers" Version="2.*">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <!-- warning NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead. -->
-    <NoWarn>NU5125;$(NoWarn)</NoWarn>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/JohannesMoersch/Functional</PackageProjectUrl>
     <Authors>Johannes Moersch</Authors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,9 +18,9 @@
     <PackageReference Include="Microsoft.Net.Compilers" Version="3.*" Condition=" '$(OS)' == 'Windows_NT' ">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <!-- <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.*">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" version="16.*">
       <PrivateAssets>all</PrivateAssets>
-    </PackageReference> -->
+    </PackageReference>
     <PackageReference Include="IDisposableAnalyzers" Version="2.*">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Functional.All/Functional.All.csproj
+++ b/Functional.All/Functional.All.csproj
@@ -1,25 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Functional.All</Title>
     <Description>This package depends on all other packages in the Functional suite.</Description>
-    <PackageProjectUrl>https://github.com/JohannesMoersch/Functional</PackageProjectUrl>
-    <Authors>Johannes Moersch</Authors>
-    <PackageTags>functional</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>Copyright © 2018 Johannes Moersch</Copyright>
-    <Version>1.11.0</Version>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Functional.AsyncEnumerables/AsyncEnumerator.cs
+++ b/Functional.AsyncEnumerables/AsyncEnumerator.cs
@@ -1,31 +1,35 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Functional
 {
-	internal class AsyncEnumerator<T> : IAsyncEnumerator<T>
-    {
+	internal class AsyncEnumerator<T> : DisposableBase, IAsyncEnumerator<T>
+	{
 		private static readonly Task<bool> _trueResult = Task.FromResult(true);
 
 		private static readonly Task<bool> _falseResult = Task.FromResult(false);
 
-		private readonly Lazy<Task<IEnumerator<T>>> _enumerator;
+		private readonly AsyncLazy<IEnumerator<T>> _enumerator;
 
-		public T Current => _enumerator.IsValueCreated && _enumerator.Value.IsCompleted ? _enumerator.Value.Result.Current : default;
+		public T Current => GetCurrentAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
-		internal AsyncEnumerator(Lazy<Task<IEnumerator<T>>> enumerator)
+		internal AsyncEnumerator(AsyncLazy<IEnumerator<T>> enumerator)
 			=> _enumerator = enumerator;
 
-		public Task<bool> MoveNext()
+		public async Task<bool> MoveNext()
 		{
-			var enumerator = _enumerator.Value;
+			var enumerator = await _enumerator.GetValueAsync().ConfigureAwait(false);
+			return enumerator.MoveNext();
+		}
 
-			if (enumerator.IsCompleted)
-				return enumerator.Result.MoveNext() ? _trueResult : _falseResult;
+		public async Task<T> GetCurrentAsync()
+		{
+			var enumerator = await _enumerator.GetValueAsync().ConfigureAwait(false);
+			return enumerator.Current;
+		}
 
-			return enumerator.ContinueWith(t => t.Result.MoveNext(), TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
+		protected override void DisposeResources()
+		{
 		}
 	}
 }

--- a/Functional.AsyncEnumerables/AsyncTaskEnumerator.cs
+++ b/Functional.AsyncEnumerables/AsyncTaskEnumerator.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Functional
 {
-	internal class AsyncTaskEnumerator<T> : IAsyncEnumerator<T>
+	internal class AsyncTaskEnumerator<T> : DisposableBase, IAsyncEnumerator<T>
 	{
 		private static readonly Task<bool> _trueResult = Task.FromResult(true);
 
@@ -20,12 +19,18 @@ namespace Functional
 
 		public Task<bool> MoveNext()
 		{
-			var enumerator = _enumerator.Value;
+			IEnumerator<Task<T>> enumerator = _enumerator.Value;
 
 			if (!enumerator.MoveNext())
+			{
 				return _falseResult;
+			}
 
 			return enumerator.Current.ContinueWith(t => { Current = t.Result; return true; }, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
+		}
+
+		protected override void DisposeResources()
+		{
 		}
 	}
 }

--- a/Functional.AsyncEnumerables/Functional.AsyncEnumerables.csproj
+++ b/Functional.AsyncEnumerables/Functional.AsyncEnumerables.csproj
@@ -1,24 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Functional.AsyncEnumerables</Title>
     <Description>This package contains a framework and extension methods for asynchronous enumerables.</Description>
-    <PackageProjectUrl>https://github.com/JohannesMoersch/Functional</PackageProjectUrl>
-    <Authors>Johannes Moersch</Authors>
-    <PackageTags>functional</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>Copyright © 2018 Johannes Moersch</Copyright>
-    <Version>1.11.0</Version>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/Functional.AsyncEnumerables/Functional.AsyncEnumerables.csproj
+++ b/Functional.AsyncEnumerables/Functional.AsyncEnumerables.csproj
@@ -1,8 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Title>Functional.AsyncEnumerables</Title>
     <Description>This package contains a framework and extension methods for asynchronous enumerables.</Description>
   </PropertyGroup>
+
+  <Import Project="..\Functional.Shared\Functional.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/Functional.AsyncEnumerables/IAsyncEnumerator.cs
+++ b/Functional.AsyncEnumerables/IAsyncEnumerator.cs
@@ -1,14 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Functional
 {
-    public interface IAsyncEnumerator<out T>
-    {
+	public interface IAsyncEnumerator<out T> : IDisposable
+	{
 		Task<bool> MoveNext();
 
 		T Current { get; }
-    }
+	}
 }

--- a/Functional.AsyncEnumerables/Iterators/BasicIterator.cs
+++ b/Functional.AsyncEnumerables/Iterators/BasicIterator.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Functional
 {
-	internal class BasicIterator<TSource, TResult> : IAsyncEnumerator<TResult>
+	internal class BasicIterator<TSource, TResult> : DisposableBase, IAsyncEnumerator<TResult>
 	{
 		private readonly IAsyncEnumerator<TSource> _enumerator;
 		private readonly Func<(TSource current, int index), (BasicIteratorContinuationType type, TResult current)> _moveNext;
@@ -24,7 +22,7 @@ namespace Functional
 		{
 			while (await _enumerator.MoveNext())
 			{
-				var (type, current) = _moveNext.Invoke((_enumerator.Current, _count++));
+				(BasicIteratorContinuationType type, TResult current) = _moveNext.Invoke((_enumerator.Current, _count++));
 
 				switch (type)
 				{
@@ -38,6 +36,10 @@ namespace Functional
 			}
 
 			return false;
+		}
+
+		protected override void DisposeResources()
+		{
 		}
 	}
 }

--- a/Functional.AsyncEnumerables/Iterators/BasicIteratorAsync.cs
+++ b/Functional.AsyncEnumerables/Iterators/BasicIteratorAsync.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Functional
 {
-	internal class BasicIteratorAsync<TSource, TResult> : IAsyncEnumerator<TResult>
+	internal class BasicIteratorAsync<TSource, TResult> : DisposableBase, IAsyncEnumerator<TResult>
 	{
 		private readonly IAsyncEnumerator<TSource> _enumerator;
 		private readonly Func<(TSource current, int index), Task<(BasicIteratorContinuationType type, TResult current)>> _moveNext;
@@ -24,7 +22,7 @@ namespace Functional
 		{
 			while (await _enumerator.MoveNext())
 			{
-				var (type, current) = await _moveNext.Invoke((_enumerator.Current, _count++));
+				(BasicIteratorContinuationType type, TResult current) = await _moveNext.Invoke((_enumerator.Current, _count++));
 
 				switch (type)
 				{
@@ -38,6 +36,10 @@ namespace Functional
 			}
 
 			return false;
+		}
+
+		protected override void DisposeResources()
+		{
 		}
 	}
 }

--- a/Functional.AsyncEnumerables/Iterators/ConcatIterator.cs
+++ b/Functional.AsyncEnumerables/Iterators/ConcatIterator.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Functional
 {
-	internal class ConcatIterator<TSource> : IAsyncEnumerator<TSource>
+	internal class ConcatIterator<TSource> : DisposableBase, IAsyncEnumerator<TSource>
 	{
 		private readonly IAsyncEnumerator<TSource> _enumeratorOne;
 		private readonly IAsyncEnumerator<TSource> _enumeratorTwo;
@@ -30,7 +28,9 @@ namespace Functional
 					return true;
 				}
 				else
+				{
 					_state = 1;
+				}
 			}
 
 			if (_state == 1)
@@ -41,10 +41,16 @@ namespace Functional
 					return true;
 				}
 				else
+				{
 					_state = 2;
+				}
 			}
 
 			return false;
+		}
+
+		protected override void DisposeResources()
+		{
 		}
 	}
 }

--- a/Functional.AsyncEnumerables/Iterators/DefaultIfEmptyIterator.cs
+++ b/Functional.AsyncEnumerables/Iterators/DefaultIfEmptyIterator.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Functional
 {
-	internal class DefaultIfEmptyIterator<TSource> : IAsyncEnumerator<TSource>
+	internal class DefaultIfEmptyIterator<TSource> : DisposableBase, IAsyncEnumerator<TSource>
 	{
 		private readonly IAsyncEnumerator<TSource> _enumerator;
 		private readonly TSource _defaultValue;
@@ -46,6 +44,10 @@ namespace Functional
 					break;
 			}
 			return false;
+		}
+
+		protected override void DisposeResources()
+		{
 		}
 	}
 }

--- a/Functional.AsyncEnumerables/Iterators/SelectManyIterator.cs
+++ b/Functional.AsyncEnumerables/Iterators/SelectManyIterator.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Functional
 {
-	internal class SelectManyIterator<TSource, TCollection, TResult> : IAsyncEnumerator<TResult>
+	internal class SelectManyIterator<TSource, TCollection, TResult> : DisposableBase, IAsyncEnumerator<TResult>
 	{
 		private readonly IAsyncEnumerator<TSource> _enumerator;
 		private readonly Func<TSource, int, IAsyncEnumerable<TCollection>> _collectionSelector;
@@ -27,7 +25,9 @@ namespace Functional
 			while (_subEnumerator == null || !await _subEnumerator.MoveNext())
 			{
 				if (!await _enumerator.MoveNext())
+				{
 					return false;
+				}
 
 				_subEnumerator = _collectionSelector.Invoke(_enumerator.Current, _count++).GetEnumerator();
 			}
@@ -35,6 +35,10 @@ namespace Functional
 			Current = _resultSelector.Invoke(_enumerator.Current, _subEnumerator.Current);
 
 			return true;
+		}
+
+		protected override void DisposeResources()
+		{
 		}
 	}
 }

--- a/Functional.AsyncEnumerables/Iterators/SelectManyIteratorAsync.cs
+++ b/Functional.AsyncEnumerables/Iterators/SelectManyIteratorAsync.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Functional
 {
-	internal class SelectManyIteratorAsync<TSource, TCollection, TResult> : IAsyncEnumerator<TResult>
+	internal class SelectManyIteratorAsync<TSource, TCollection, TResult> : DisposableBase, IAsyncEnumerator<TResult>
 	{
 		private readonly IAsyncEnumerator<TSource> _enumerator;
 		private readonly Func<TSource, int, IAsyncEnumerable<TCollection>> _collectionSelector;
@@ -27,7 +25,9 @@ namespace Functional
 			while (_subEnumerator == null || !await _subEnumerator.MoveNext())
 			{
 				if (!await _enumerator.MoveNext())
+				{
 					return false;
+				}
 
 				_subEnumerator = _collectionSelector.Invoke(_enumerator.Current, _count++).GetEnumerator();
 			}
@@ -35,6 +35,10 @@ namespace Functional
 			Current = await _resultSelector.Invoke(_enumerator.Current, _subEnumerator.Current);
 
 			return true;
+		}
+
+		protected override void DisposeResources()
+		{
 		}
 	}
 }

--- a/Functional.AsyncEnumerables/Iterators/ZipIterator.cs
+++ b/Functional.AsyncEnumerables/Iterators/ZipIterator.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Functional
 {
-	internal class ZipIterator<TFirst, TSecond, TResult> : IAsyncEnumerator<TResult>
+	internal class ZipIterator<TFirst, TSecond, TResult> : DisposableBase, IAsyncEnumerator<TResult>
 	{
 		private readonly IAsyncEnumerator<TFirst> _enumeratorOne;
 		private readonly IAsyncEnumerator<TSecond> _enumeratorTwo;
@@ -25,7 +23,9 @@ namespace Functional
 		public async Task<bool> MoveNext()
 		{
 			if (_complete)
+			{
 				return false;
+			}
 
 			if (await _enumeratorOne.MoveNext() && await _enumeratorTwo.MoveNext())
 			{
@@ -33,9 +33,15 @@ namespace Functional
 				return true;
 			}
 			else
+			{
 				_complete = true;
+			}
 
 			return false;
+		}
+
+		protected override void DisposeResources()
+		{
 		}
 	}
 }

--- a/Functional.AsyncEnumerables/Iterators/ZipIteratorAsync.cs
+++ b/Functional.AsyncEnumerables/Iterators/ZipIteratorAsync.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Functional
 {
-	internal class ZipIteratorAsync<TFirst, TSecond, TResult> : IAsyncEnumerator<TResult>
+	internal class ZipIteratorAsync<TFirst, TSecond, TResult> : DisposableBase, IAsyncEnumerator<TResult>
 	{
 		private readonly IAsyncEnumerator<TFirst> _enumeratorOne;
 		private readonly IAsyncEnumerator<TSecond> _enumeratorTwo;
@@ -25,7 +23,9 @@ namespace Functional
 		public async Task<bool> MoveNext()
 		{
 			if (_complete)
+			{
 				return false;
+			}
 
 			if (await _enumeratorOne.MoveNext() && await _enumeratorTwo.MoveNext())
 			{
@@ -33,9 +33,15 @@ namespace Functional
 				return true;
 			}
 			else
+			{
 				_complete = true;
+			}
 
 			return false;
+		}
+
+		protected override void DisposeResources()
+		{
 		}
 	}
 }

--- a/Functional.Common.Extensions/Functional.Common.Extensions.csproj
+++ b/Functional.Common.Extensions/Functional.Common.Extensions.csproj
@@ -1,24 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Functional.Common.Extensions</Title>
     <Description>This package contains extension methods for .NET types.</Description>
-    <PackageProjectUrl>https://github.com/JohannesMoersch/Functional</PackageProjectUrl>
-    <Authors>Johannes Moersch</Authors>
-    <PackageTags>functional</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>Copyright © 2018 Johannes Moersch</Copyright>
-    <Version>1.11.0</Version>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Functional.Enumerables.Extensions/Functional.Enumerables.Extensions.csproj
+++ b/Functional.Enumerables.Extensions/Functional.Enumerables.Extensions.csproj
@@ -1,24 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Functional.Enumerables.Extensions</Title>
     <Description>This package contains extension methods that add support for Task&lt;IEnumerable&lt;T&gt;&gt; to LINQ.</Description>
-    <PackageProjectUrl>https://github.com/JohannesMoersch/Functional</PackageProjectUrl>
-    <Authors>Johannes Moersch</Authors>
-    <PackageTags>functional</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>Copyright © 2018 Johannes Moersch</Copyright>
-    <Version>1.11.0</Version>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Functional.Enumerables.Extensions/PartitionExtensions.cs
+++ b/Functional.Enumerables.Extensions/PartitionExtensions.cs
@@ -3,8 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Functional
 {
@@ -39,7 +37,9 @@ namespace Functional
 						return true;
 					}
 					else
+					{
 						_complete = true;
+					}
 				}
 
 				value = default;
@@ -64,7 +64,7 @@ namespace Functional
 
 			public bool MoveNext()
 			{
-				if (_index >= 0 && _data.TryGetValue(_index++, out var value))
+				if (_index >= 0 && _data.TryGetValue(_index++, out T value))
 				{
 					Current = value;
 					return true;
@@ -95,13 +95,15 @@ namespace Functional
 		public static Partition<T> Partition<T>(this IEnumerable<T> source, Func<T, bool> predicate)
 		{
 			if (predicate == null)
+			{
 				throw new ArgumentNullException(nameof(predicate));
+			}
 
 			var values = new ReplayableEnumerable<(bool matches, T value)>(source.Select(value => (predicate.Invoke(value), value)));
 
 			return new Partition<T>
 			(
-				values.Where(set => set.matches).Select(set => set.value), 
+				values.Where(set => set.matches).Select(set => set.value),
 				values.Where(set => !set.matches).Select(set => set.value)
 			);
 		}

--- a/Functional.Primitives.AsyncEnumerables/Functional.Primitives.AsyncEnumerables.csproj
+++ b/Functional.Primitives.AsyncEnumerables/Functional.Primitives.AsyncEnumerables.csproj
@@ -1,24 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Functional.Enumerables.Extensions</Title>
     <Description>This package contains a extension methods for primitives and async enumerables.</Description>
-    <PackageProjectUrl>https://github.com/JohannesMoersch/Functional</PackageProjectUrl>
-    <Authors>Johannes Moersch</Authors>
-    <PackageTags>functional</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>Copyright © 2018 Johannes Moersch</Copyright>
-    <Version>1.11.0</Version>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Functional.Primitives.AsyncEnumerables/Functional.Primitives.AsyncEnumerables.csproj
+++ b/Functional.Primitives.AsyncEnumerables/Functional.Primitives.AsyncEnumerables.csproj
@@ -11,4 +11,6 @@
     <ProjectReference Include="..\Functional.Primitives\Functional.Primitives.csproj" />
   </ItemGroup>
 
+  <Import Project="..\Functional.Shared\Functional.Shared.projitems" Label="Shared" />
+
 </Project>

--- a/Functional.Primitives.AsyncEnumerables/OptionLinqSyntaxGroupExtensions.cs
+++ b/Functional.Primitives.AsyncEnumerables/OptionLinqSyntaxGroupExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Functional
@@ -47,7 +46,7 @@ namespace Functional
 				=> new OptionGroupByEnumerator<TKey, TSuccess, TElement>(_successEnumerable.GetEnumerator(), _keySelector, _elementSelector);
 		}
 
-		private class OptionGroupByEnumerator<TKey, TSuccess, TElement> : IEnumerator<Option<IGrouping<TKey, TElement>>>
+		private class OptionGroupByEnumerator<TKey, TSuccess, TElement> : DisposableBase, IEnumerator<Option<IGrouping<TKey, TElement>>>
 		{
 			private class Grouping : IGrouping<TKey, TElement>
 			{
@@ -87,8 +86,7 @@ namespace Functional
 				_elementSelector = elementSelector;
 			}
 
-			public void Dispose()
-				=> _groupingEnumerator?.Dispose();
+			protected override void DisposeResources() => _groupingEnumerator?.Dispose();
 
 			public bool MoveNext()
 			{
@@ -103,7 +101,7 @@ namespace Functional
 							(
 								success =>
 								{
-									if (!_groupings.TryGetValue(success.key, out var items))
+									if (!_groupings.TryGetValue(success.key, out List<TElement> items))
 									{
 										items = new List<TElement>();
 										_groupings.Add(success.key, items);
@@ -122,7 +120,9 @@ namespace Functional
 							);
 
 						if (isFailure)
+						{
 							return true;
+						}
 					}
 
 					_groupingEnumerator = _groupings.GetEnumerator();
@@ -142,6 +142,7 @@ namespace Functional
 			{
 				_successEnumerator.Reset();
 				_groupings.Clear();
+				_groupingEnumerator?.Dispose();
 				_groupingEnumerator = null;
 				Current = default;
 			}
@@ -218,7 +219,7 @@ namespace Functional
 							(
 								success =>
 								{
-									if (!_groupings.TryGetValue(success.key, out var items))
+									if (!_groupings.TryGetValue(success.key, out List<TElement> items))
 									{
 										items = new List<TElement>();
 										_groupings.Add(success.key, items);
@@ -237,7 +238,9 @@ namespace Functional
 							);
 
 						if (isFailure)
+						{
 							return true;
+						}
 					}
 
 					_groupingEnumerator = _groupings.GetEnumerator();

--- a/Functional.Primitives.AsyncEnumerables/ResultLinqSyntaxGroupExtensions.cs
+++ b/Functional.Primitives.AsyncEnumerables/ResultLinqSyntaxGroupExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Functional
@@ -103,7 +102,7 @@ namespace Functional
 							(
 								success =>
 								{
-									if (!_groupings.TryGetValue(success.key, out var items))
+									if (!_groupings.TryGetValue(success.key, out List<TElement> items))
 									{
 										items = new List<TElement>();
 										_groupings.Add(success.key, items);
@@ -122,7 +121,9 @@ namespace Functional
 							);
 
 						if (isFailure)
+						{
 							return true;
+						}
 					}
 
 					_groupingEnumerator = _groupings.GetEnumerator();
@@ -142,6 +143,7 @@ namespace Functional
 			{
 				_successEnumerator.Reset();
 				_groupings.Clear();
+				_groupingEnumerator?.Dispose();
 				_groupingEnumerator = null;
 				Current = default;
 			}
@@ -164,7 +166,7 @@ namespace Functional
 				=> new AsyncResultGroupByEnumerator<TKey, TSuccess, TElement, TFailure>(_successEnumerable.GetEnumerator(), _keySelector, _elementSelector);
 		}
 
-		private class AsyncResultGroupByEnumerator<TKey, TSuccess, TElement, TFailure> : IAsyncEnumerator<Result<IGrouping<TKey, TElement>, TFailure>>
+		private class AsyncResultGroupByEnumerator<TKey, TSuccess, TElement, TFailure> : DisposableBase, IAsyncEnumerator<Result<IGrouping<TKey, TElement>, TFailure>>
 		{
 			private class Grouping : IGrouping<TKey, TElement>
 			{
@@ -202,8 +204,7 @@ namespace Functional
 				_elementSelector = elementSelector;
 			}
 
-			public void Dispose()
-				=> _groupingEnumerator?.Dispose();
+			protected override void DisposeResources() => _groupingEnumerator?.Dispose();
 
 			public async Task<bool> MoveNext()
 			{
@@ -218,7 +219,7 @@ namespace Functional
 							(
 								success =>
 								{
-									if (!_groupings.TryGetValue(success.key, out var items))
+									if (!_groupings.TryGetValue(success.key, out List<TElement> items))
 									{
 										items = new List<TElement>();
 										_groupings.Add(success.key, items);
@@ -237,7 +238,9 @@ namespace Functional
 							);
 
 						if (isFailure)
+						{
 							return true;
+						}
 					}
 
 					_groupingEnumerator = _groupings.GetEnumerator();

--- a/Functional.Primitives.Extensions/Functional.Primitives.Extensions.csproj
+++ b/Functional.Primitives.Extensions/Functional.Primitives.Extensions.csproj
@@ -1,24 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Functional.Primitives.Extensions</Title>
     <Description>This package contains a suite of extension methods for working with Option and Result types.</Description>
-    <PackageProjectUrl>https://github.com/JohannesMoersch/Functional</PackageProjectUrl>
-    <Authors>Johannes Moersch + contributors</Authors>
-    <PackageTags>functional</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>Copyright © 2018 Johannes Moersch</Copyright>
-    <Version>1.11.0</Version>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Functional.Primitives/Functional.Primitives.csproj
+++ b/Functional.Primitives/Functional.Primitives.csproj
@@ -1,24 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Functional.Primitives</Title>
     <Description>This package contains allocation free Option and Result discriminated union types and associated factory methods.</Description>
-    <PackageProjectUrl>https://github.com/JohannesMoersch/Functional</PackageProjectUrl>
-    <Authors>Johannes Moersch</Authors>
-    <PackageTags>functional</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>Copyright © 2018 Johannes Moersch</Copyright>
-    <Version>1.11.0</Version>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/Functional.Shared/AsyncLazy.cs
+++ b/Functional.Shared/AsyncLazy.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Functional
+{
+	internal class AsyncLazy<TValue> : DisposableBase
+	{
+		private readonly TaskCompletionSource<TValue> _tcs = new TaskCompletionSource<TValue>();
+
+		private readonly Func<Task<TValue>> _taskFactory;
+
+		private int _taskInitiated;
+
+		public AsyncLazy(Func<Task<TValue>> taskFactory) => _taskFactory = taskFactory ?? throw new ArgumentNullException(nameof(taskFactory));
+
+		public bool IsValueCreated => _tcs.Task.Status == TaskStatus.RanToCompletion;
+
+		// For callers that want a task
+		public async Task<TValue> GetValueAsync()
+		{
+			// Did someone else already kick off the task?
+			if (Interlocked.CompareExchange(ref _taskInitiated, 1, 0) == 1)
+			{
+				return await _tcs.Task.ConfigureAwait(false);
+			}
+
+			// We're first, so we need to kick off the task
+			try
+			{
+				Task<TValue> task = _taskFactory();
+				TValue result = await task.ConfigureAwait(false);
+				_tcs.SetResult(result);
+				return result;
+			}
+			catch (OperationCanceledException)
+			{
+				_tcs.SetCanceled();
+				throw;
+			}
+			catch (Exception exception)
+			{
+				_tcs.SetException(exception);
+				throw;
+			}
+		}
+
+		protected override void DisposeResources()
+		{
+			if (IsValueCreated)
+			{
+				if (GetValueAsync().ConfigureAwait(false).GetAwaiter().GetResult() is IDisposable disposable)
+				{
+					disposable?.Dispose();
+				}
+			}
+		}
+	}
+}

--- a/Functional.Shared/DisposableBase.cs
+++ b/Functional.Shared/DisposableBase.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+namespace Functional
+{
+	internal interface IDisposableObservable : IDisposable
+	{
+		/// <summary>
+		/// Gets a value indicating whether this object has been disposed.
+		/// </summary>
+		bool IsDisposed { get; }
+	}
+
+	/// <summary>
+	/// Implements the IDisposable pattern
+	/// </summary>
+	internal abstract class DisposableBase : IDisposableObservable
+	{
+		public bool IsDisposed { get; private set; }
+
+		/// <summary>
+		/// Finalizes an instance of the <see cref="DisposableBase"/> class.
+		/// </summary>
+		~DisposableBase()
+		{
+			Dispose(false);
+		}
+
+		/// <inheritdoc/>
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		/// <summary>
+		/// Dispose resources.
+		/// </summary>
+		/// <param name="disposing">True if called explicitly, false if called through the destructor.</param>
+		protected virtual void Dispose(bool disposing)
+		{
+			if (IsDisposed)
+			{
+				return;
+			}
+
+			if (disposing)
+			{
+				DisposeResources();
+			}
+
+			IsDisposed = true;
+		}
+
+		/// <summary>
+		/// Release resources. base.Dispose() should not be called from this method. 
+		/// </summary>
+		protected abstract void DisposeResources();
+	}
+}

--- a/Functional.Shared/Functional.Shared.projitems
+++ b/Functional.Shared/Functional.Shared.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>42507d50-903c-45c2-8ef5-530f4a6ad8d8</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Functional.Shared</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)**/*.cs" />
+  </ItemGroup>
+</Project>

--- a/Functional.Shared/Functional.Shared.shproj
+++ b/Functional.Shared/Functional.Shared.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>42507d50-903c-45c2-8ef5-530f4a6ad8d8</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="Functional.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/Functional.Tests/Functional.Tests.csproj
+++ b/Functional.Tests/Functional.Tests.csproj
@@ -1,25 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-
+    <TargetFrameworks>netcoreapp2.0;net472;</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="FluentAssertions" Version="5.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Functional.Tests/Functional.Tests.csproj
+++ b/Functional.Tests/Functional.Tests.csproj
@@ -1,7 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net472;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">
+      net472;$(TargetFrameworks)
+    </TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Functional.Unions.AsyncEnumerables/AsyncUnionPartitionExtensions.cs
+++ b/Functional.Unions.AsyncEnumerables/AsyncUnionPartitionExtensions.cs
@@ -52,7 +52,6 @@ namespace Functional
 
 			protected override void DisposeResources()
 			{
-				throw new NotImplementedException();
 			}
 
 			public async Task<bool> MoveNext()

--- a/Functional.Unions.AsyncEnumerables/AsyncUnionPartitionExtensions.cs
+++ b/Functional.Unions.AsyncEnumerables/AsyncUnionPartitionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Functional
@@ -40,7 +39,7 @@ namespace Functional
 			}
 		}
 
-		private class ReplayableAsyncEnumerator<T> : IAsyncEnumerator<T>
+		private class ReplayableAsyncEnumerator<T> : DisposableBase, IAsyncEnumerator<T>
 		{
 			public T Current { get; private set; }
 
@@ -51,7 +50,10 @@ namespace Functional
 			public ReplayableAsyncEnumerator(ReplayableAsyncEnumerableData<T> data)
 				=> _data = data;
 
-			public void Dispose() { }
+			protected override void DisposeResources()
+			{
+				throw new NotImplementedException();
+			}
 
 			public async Task<bool> MoveNext()
 			{

--- a/Functional.Unions.AsyncEnumerables/Functional.Unions.AsyncEnumerables.csproj
+++ b/Functional.Unions.AsyncEnumerables/Functional.Unions.AsyncEnumerables.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Title>Functional.Unions.AsyncEnumerables</Title>
@@ -11,5 +11,7 @@
     <ProjectReference Include="..\Functional.Unions.Extensions\Functional.Unions.Extensions.csproj" />
     <ProjectReference Include="..\Functional.Unions\Functional.Unions.csproj" />
   </ItemGroup>
+
+  <Import Project="..\Functional.Shared\Functional.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/Functional.Unions.AsyncEnumerables/Functional.Unions.AsyncEnumerables.csproj
+++ b/Functional.Unions.AsyncEnumerables/Functional.Unions.AsyncEnumerables.csproj
@@ -1,24 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Functional.Unions.AsyncEnumerables</Title>
     <Description>This package contains a extension methods for unions and async enumerables.</Description>
-    <PackageProjectUrl>https://github.com/JohannesMoersch/Functional</PackageProjectUrl>
-    <Authors>Johannes Moersch</Authors>
-    <PackageTags>functional</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>Copyright © 2018 Johannes Moersch</Copyright>
-    <Version>1.11.0</Version>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Functional.Unions.AsyncEnumerables/UnionPartitionExtensions.cs
+++ b/Functional.Unions.AsyncEnumerables/UnionPartitionExtensions.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
 
 namespace Functional
 {
@@ -38,7 +35,9 @@ namespace Functional
 						return true;
 					}
 					else
+					{
 						_complete = true;
+					}
 				}
 
 				value = default;
@@ -63,7 +62,7 @@ namespace Functional
 
 			public bool MoveNext()
 			{
-				if (_index >= 0 && _data.TryGetValue(_index++, out var value))
+				if (_index >= 0 && _data.TryGetValue(_index++, out T value))
 				{
 					Current = value;
 					return true;
@@ -81,8 +80,7 @@ namespace Functional
 		{
 			private readonly ReplayableEnumerableData<T> _data;
 
-			public ReplayableEnumerable(IEnumerable<T> data)
-				=> _data = new ReplayableEnumerableData<T>(data.GetEnumerator());
+			public ReplayableEnumerable(IEnumerable<T> data) => _data = new ReplayableEnumerableData<T>(data.GetEnumerator());
 
 			public IEnumerator<T> GetEnumerator()
 				=> new ReplayableEnumerator<T>(_data);

--- a/Functional.Unions.Extensions/Functional.Unions.Extensions.csproj
+++ b/Functional.Unions.Extensions/Functional.Unions.Extensions.csproj
@@ -1,24 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Functional.Unions.Extensions</Title>
     <Description>This package contains extension methods for working with Union types.</Description>
-    <PackageProjectUrl>https://github.com/JohannesMoersch/Functional</PackageProjectUrl>
-    <Authors>Johannes Moersch</Authors>
-    <PackageTags>functional</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>Copyright © 2018 Johannes Moersch</Copyright>
-    <Version>1.11.0</Version>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Functional.Unions/Functional.Unions.csproj
+++ b/Functional.Unions/Functional.Unions.csproj
@@ -1,24 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Functional.Unions</Title>
     <Description>This package contains discriminated union types for arbitrary unions of 2 to 8 types and associated factory methods.</Description>
-    <PackageProjectUrl>https://github.com/JohannesMoersch/Functional</PackageProjectUrl>
-    <Authors>Johannes Moersch</Authors>
-    <PackageTags>functional</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>Copyright © 2018 Johannes Moersch</Copyright>
-    <Version>1.11.0</Version>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/Functional.sln
+++ b/Functional.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2015
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.156
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Functional.Primitives", "Functional.Primitives\Functional.Primitives.csproj", "{77BA7FE8-AF44-47B0-BE4A-39787D45B04E}"
 EndProject
@@ -30,7 +30,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Functional.Shared", "Functional.Shared\Functional.Shared.shproj", "{42507D50-903C-45C2-8EF5-530F4A6AD8D8}"
+EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Functional.Shared\Functional.Shared.projitems*{42507d50-903c-45c2-8ef5-530f4a6ad8d8}*SharedItemsImports = 13
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU


### PR DESCRIPTION
Move common project properties into common Directory.Build.props which is a hook that msbuild will automatically pickup