### PR TITLE
Fix concurrent dictionary try remove

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Authors>Johannes Moersch + contributers</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © 2020 Johannes Moersch</Copyright>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
 
 </Project>

--- a/Functional.Common.Extensions/DictionaryExtensions.cs
+++ b/Functional.Common.Extensions/DictionaryExtensions.cs
@@ -21,6 +21,6 @@ namespace Functional
 			=> Option.Create(source.TryGetValue(key, out var value) && value != null, value);
 
 		public static Option<TValue> TryRemove<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> source, TKey key)
-			=> Option.Create(source.TryGetValue(key, out var value) && value != null, value);
+			=> Option.Create(source.TryRemove(key, out var value) && value != null, value);
 	}
 }

--- a/Functional.Tests/Common/DictionaryExtensionsTests.cs
+++ b/Functional.Tests/Common/DictionaryExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
@@ -43,6 +44,34 @@ namespace Functional.Tests.Common
 			=> new Dictionary<int, int?>() { { 1, null } }
 				.TryGetValue(1)
 				.AssertNone();
+
+		[Fact]
+		public void TryRemoveValueWhenKeyPresentAndIntegerValueNotNull()
+		{
+			var dictionary = new ConcurrentDictionary<int, int?>();
+			dictionary.TryAdd(1, 1);
+			
+			dictionary
+				.TryRemove(1)
+				.AssertSome()
+				.Should()
+				.Be(1);
+
+			dictionary.ContainsKey(1).Should().BeFalse();
+		}
+
+		[Fact]
+		public void TryRemoveValueWhenKeyPresentAndIntegerValueNull()
+		{
+			var dictionary = new ConcurrentDictionary<int, int?>();
+			dictionary.TryAdd(1, null);
+
+			dictionary
+				.TryRemove(1)
+				.AssertNone();
+
+			dictionary.ContainsKey(1).Should().BeFalse();
+		}
 	}
 
 	public class One


### PR DESCRIPTION
A copy-paste error appears to have caused a bug: The `Option<T>`-returning `ConcurrentDictionary.TryRemove` method does not remove the item.