### PR TITLE
Transpose and Evert

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Authors>Johannes Moersch + contributers</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © 2020 Johannes Moersch</Copyright>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/Functional.Primitives.Extensions/ResultExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultExtensions.cs
@@ -162,7 +162,7 @@ namespace Functional
 			=> (await result).TryMap(successFactory, DelegateCache<Exception>.Passthrough);
 
 		public static Result<T2, T1> Transpose<T1, T2>(this Result<T1, T2> source)
-			=> source.Match(Result.Failure<T2, T1>, Result.Success<T2, T1>);
+			=> source.TryGetValue(out var success, out var failure) ? Result.Failure<T2, T1>(success) : Result.Success<T2, T1>(failure);
 
 		public static async Task<Result<T2, T1>> Transpose<T1, T2>(this Task<Result<T1, T2>> source)
 			=> (await source).Transpose();

--- a/Functional.Primitives.Extensions/ResultExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultExtensions.cs
@@ -6,25 +6,6 @@ using System.Threading.Tasks;
 
 namespace Functional
 {
-	public static partial class ResultOptionExtensions
-	{
-		public static Result<TSuccess, TFailure> Do<TSuccess, TFailure>(this Result<TSuccess, TFailure> result, Action<TSuccess> onSuccess, Action<TFailure> onFailure)
-		{
-			if (onSuccess == null)
-				throw new ArgumentNullException(nameof(onSuccess));
-
-			if (onFailure == null)
-				throw new ArgumentNullException(nameof(onFailure));
-
-			if (result.TryGetValue(out var success, out var failure))
-				onSuccess.Invoke(success);
-			else
-				onFailure.Invoke(failure);
-
-			return result;
-		}
-	}
-
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static partial class ResultExtensions
 	{
@@ -117,6 +98,22 @@ namespace Functional
 		public static async Task<Result<TSuccess, TFailure>> BindOnFailure<TSuccess, TFailure>(this Task<Result<TSuccess, TFailure>> result, Func<TFailure, Result<TSuccess, TFailure>> bind)
 			=> (await result).BindOnFailure(bind);
 
+		public static Result<TSuccess, TFailure> Do<TSuccess, TFailure>(this Result<TSuccess, TFailure> result, Action<TSuccess> onSuccess, Action<TFailure> onFailure)
+		{
+			if (onSuccess == null)
+				throw new ArgumentNullException(nameof(onSuccess));
+
+			if (onFailure == null)
+				throw new ArgumentNullException(nameof(onFailure));
+
+			if (result.TryGetValue(out var success, out var failure))
+				onSuccess.Invoke(success);
+			else
+				onFailure.Invoke(failure);
+
+			return result;
+		}
+
 		public static async Task<Result<TSuccess, TFailure>> Do<TSuccess, TFailure>(this Task<Result<TSuccess, TFailure>> result, Action<TSuccess> success, Action<TFailure> failure)
 			=> (await result).Do(success, failure);
 
@@ -163,6 +160,12 @@ namespace Functional
 
 		public static async Task<Result<TResult, Exception>> TryMap<TSuccess, TResult>(this Task<Result<TSuccess, Exception>> result, Func<TSuccess, TResult> successFactory)
 			=> (await result).TryMap(successFactory, DelegateCache<Exception>.Passthrough);
+
+		public static Result<T2, T1> Transpose<T1, T2>(this Result<T1, T2> source)
+			=> source.Match(Result.Failure<T2, T1>, Result.Success<T2, T1>);
+
+		public static async Task<Result<T2, T1>> Transpose<T1, T2>(this Task<Result<T1, T2>> source)
+			=> (await source).Transpose();
 	}
 }
 	

--- a/Functional.Primitives.Extensions/ResultOptionExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultOptionExtensions.cs
@@ -156,11 +156,16 @@ namespace Functional
 			=> (await result).DoOnSome(onSuccessSome);
 
 		public static Result<Option<TSuccess>, TFailure> Evert<TSuccess, TFailure>(this Option<Result<TSuccess, TFailure>> source)
-			=> source.Match(
-				some => some.Match(
-					success => Result.Success<Option<TSuccess>, TFailure>(Option.Some(success)),
-					Result.Failure<Option<TSuccess>, TFailure>),
-				() => Result.Success<Option<TSuccess>, TFailure>(Option.None<TSuccess>()));
+		{
+			if (source.TryGetValue(out var some))
+			{
+				return some.TryGetValue(out var success, out var failure)
+					? Result.Success<Option<TSuccess>, TFailure>(Option.Some(success))
+					: Result.Failure<Option<TSuccess>, TFailure>(failure);
+			}
+
+			return Result.Success<Option<TSuccess>, TFailure>(Option.None<TSuccess>());
+		}
 
 		public static async Task<Result<Option<TSuccess>, TFailure>> Evert<TSuccess, TFailure>(this Task<Option<Result<TSuccess, TFailure>>> source)
 			=> (await source).Evert();

--- a/Functional.Primitives.Extensions/ResultOptionExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultOptionExtensions.cs
@@ -154,5 +154,15 @@ namespace Functional
 
 		public static async Task<Result<Option<TSuccess>, TFailure>> DoOnSome<TSuccess, TFailure>(this Task<Result<Option<TSuccess>, TFailure>> result, Action<TSuccess> onSuccessSome)
 			=> (await result).DoOnSome(onSuccessSome);
+
+		public static Result<Option<TSuccess>, TFailure> Evert<TSuccess, TFailure>(this Option<Result<TSuccess, TFailure>> source)
+			=> source.Match(
+				some => some.Match(
+					success => Result.Success<Option<TSuccess>, TFailure>(Option.Some(success)),
+					Result.Failure<Option<TSuccess>, TFailure>),
+				() => Result.Success<Option<TSuccess>, TFailure>(Option.None<TSuccess>()));
+
+		public static async Task<Result<Option<TSuccess>, TFailure>> Evert<TSuccess, TFailure>(this Task<Option<Result<TSuccess, TFailure>>> source)
+			=> (await source).Evert();
 	}
 }

--- a/Functional.Tests/Results/ResultFactoryTests.cs
+++ b/Functional.Tests/Results/ResultFactoryTests.cs
@@ -398,6 +398,40 @@ namespace Functional.Tests.Results
 				.Should()
 				.Be("abc");
 
+		[Fact]
+		public void TransposeSuccess()
+			=> Result
+				.Unit<string>()
+				.Transpose()
+				.AssertFailure()
+				.Should()
+				.Be(Functional.Unit.Value);
+
+		[Fact]
+		public Task TransposeSuccessAsync()
+			=> Task.FromResult(Result.Unit<string>())
+				.Transpose()
+				.AssertFailure()
+				.Should()
+				.Be(Functional.Unit.Value);
+
+		[Fact]
+		public void TransposeFailure()
+			=> Result
+				.Failure<Unit, string>("message")
+				.Transpose()
+				.AssertSuccess()
+				.Should()
+				.Be("message");
+
+		[Fact]
+		public Task TransposeFailureAsync()
+			=> Task.FromResult(Result.Failure<Unit, string>("message"))
+				.Transpose()
+				.AssertSuccess()
+				.Should()
+				.Be("message");
+
 		public class WhenZip2
 		{
 			[Fact]

--- a/Functional.Tests/Results/ResultOptionExtensionsTests.cs
+++ b/Functional.Tests/Results/ResultOptionExtensionsTests.cs
@@ -1151,6 +1151,36 @@ namespace Functional.Tests.Results
 					private static Task<Result<Option<int>, string>> ErrorResult() => Task.FromResult(Result.Failure<Option<int>, string>(ERROR));
 				}
 			}
+
+			public class AndEvert
+			{
+				private const int SUCCESS = 1337;
+				private const string FAILURE = "error";
+
+				[Fact]
+				public void EvertSome()
+					=> Option.Some(Result.Success<int, string>(SUCCESS))
+						.Evert()
+						.AssertSuccess()
+						.AssertSome()
+						.Should()
+						.Be(SUCCESS);
+
+				[Fact]
+				public void EvertNone()
+					=> Option.None<Result<int, string>>()
+						.Evert()
+						.AssertSuccess()
+						.AssertNone();
+
+				[Fact]
+				public void EvertError()
+					=> Option.Some(Result.Failure<int, string>(FAILURE))
+						.Evert()
+						.AssertFailure()
+						.Should()
+						.Be(FAILURE);
+			}
 		}
 
 		public class WhenTaskOfResultOfOption
@@ -1797,6 +1827,36 @@ namespace Functional.Tests.Results
 					});
 					methodCalled.Should().BeFalse();
 				}
+			}
+
+			public class AndEvert
+			{
+				private const int SUCCESS = 1337;
+				private const string FAILURE = "error";
+
+				[Fact]
+				public async Task EvertSome()
+					=> await Task.FromResult(Option.Some(Result.Success<int, string>(SUCCESS)))
+						.Evert()
+						.AssertSuccess()
+						.AssertSome()
+						.Should()
+						.Be(SUCCESS);
+
+				[Fact]
+				public async Task EvertNone()
+					=> await Task.FromResult(Option.None<Result<int, string>>())
+						.Evert()
+						.AssertSuccess()
+						.AssertNone();
+
+				[Fact]
+				public async Task EvertError()
+					=> await Task.FromResult(Option.Some(Result.Failure<int, string>(FAILURE)))
+						.Evert()
+						.AssertFailure()
+						.Should()
+						.Be(FAILURE);
 			}
 		}
 	}

--- a/README.md
+++ b/README.md
@@ -234,6 +234,15 @@ Result.Failure<int, string>("Failure").Do(s => Console.WriteLine(s)); // Does no
 Result.Failure<int, string>("Failure").Do(s => Console.WriteLine(s), f => Console.WriteLine(f)); // Outputs "Failure" to the console
 ```
 
+#### Transpose
+
+This extension returns a Result with `Success` and `Failure` values reversed.
+
+```csharp
+Result.Success<int, string>(100).Transpose(); // Returns Result<string, int> with a failure value of 100
+Result.Failure<int, string>("message").Transpose(); // Returns Result<string, int> with a success value of "message"
+```
+
 #### MapOnSome
 
 This extension is only available for `Result<Option<T>, TFailure>` types.  If `Success` and holds an Option with a value, this extension will invoke the delegate parameter.  If `Success` and holds an Option with no value, the delegate parameter will *not* be invoked, but this extension method will return a `Success` Result holding an Option with no value for the type that would have been produced by the delegate parameter.  If `Failure` it will return a `Failure` Result with the existing failure value.
@@ -296,7 +305,7 @@ Result<Option<int>, string> result = Result.Failure<Option<int>, string>("Failur
 
 #### DoOnSome
 
-This extension is only available for `Result<Option<T>, TFailure>` types.  It retuns the input Result and is meant only to create side effects.  If `Success` and holds an Option with a value, this extension will invoke the delegate parameter.
+This extension is only available for `Result<Option<T>, TFailure>` types.  It returns the input Result and is meant only to create side effects.  If `Success` and holds an Option with a value, this extension will invoke the delegate parameter.
 
 ```csharp
 Result<Option<int>, string> result = Result.Success<Option<int>, string>(Option.Some(100)).DoOnSome(i => Console.WriteLine(i)); // Outputs "100" to the console and returns Result<Option<int>, string> with a success value of Option.Some(100)
@@ -312,6 +321,16 @@ This extension is only available for `Result<Option<T>, TFailure>` types.  It re
 Result.Success<Option<int>, string>(Option.Some(100)).ApplyOnSome(i => Console.WriteLine(i)); // Outputs "100" to the console
 Result.Success<Option<int>, string>(Option.None<int>()).ApplyOnSome(i => Console.WriteLine(i)); // Does nothing
 Result.Failure<Option<int>, string>("Failure").ApplyOnSome(i => Console.WriteLine(i)); // Does nothing
+```
+
+#### Evert
+
+This extension is only available for `Option<Result<TSuccess, TFailure>>` types.  If `Some` and holds a `Success` Result, it returns a `Success` Result holding an Option with a value.  If `Some` and holds a `Failure` Result, it returns a `Failure` Result with the original failure.  If `None`, it returns a `Success` Result holding an Option with no value.
+
+``` csharp
+Option.Some(Result.Success<int, string>(1337)).Evert(); // Returns Result<Option<int>, string> with a success value of Option.Some(1337)
+Option.None<Result<int, string>>().Evert(); // Returns Result<Option<int>, string> with a success value of Option.None<int>
+Option.Some(Result.Failure<int, string>("error")).Evert(); // Returns Result<Option<int>, string> with a failure value of "error"
 ```
 
 ## Query Expressions


### PR DESCRIPTION
Closes #29 

I added both [`Transpose`](https://en.wiktionary.org/wiki/transpose#English) ("swap; interchange") and [`Evert`](https://en.wiktionary.org/wiki/evert#English) ("turn inside out") extension methods.
- `Transpose` takes `Result<T1, T2>` as input and produces `Result<T2, T1>`
- `Evert` takes `Option<Result<TSuccess, TFailure>>` as input and produces `Result<Option<TSuccess>, TFailure>`

~The names are different so that it is easy to disambiguate between the two methods; there may have been conflicts otherwise since the function signatures are similar.  I don't see `Evert` being a common use case, so I am OK with a lesser-known name.~  The two methods operate on different types, so there would be no conflicts.  I do like the separate names though.