### PR TITLE
Added TResult generic parameter to BindOnFailure and BindOnFailureAsync

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Authors>Johannes Moersch + contributers</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © 2020 Johannes Moersch</Copyright>
-    <Version>2.3.0</Version>
+    <Version>2.3.1</Version>
   </PropertyGroup>
 
 </Project>

--- a/Functional.Primitives.Extensions/ResultAsyncExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultAsyncExtensions.cs
@@ -79,16 +79,16 @@ namespace Functional
 		public static async Task<Result<TResult, TFailure>> BindAsync<TSuccess, TFailure, TResult>(this Task<Result<TSuccess, TFailure>> result, Func<TSuccess, Task<Result<TResult, TFailure>>> bind)
 			=> await (await result).BindAsync(bind);
 
-		public static async Task<Result<TSuccess, TFailure>> BindOnFailureAsync<TSuccess, TFailure>(this Result<TSuccess, TFailure> result, Func<TFailure, Task<Result<TSuccess, TFailure>>> bind)
+		public static async Task<Result<TSuccess, TResult>> BindOnFailureAsync<TSuccess, TFailure, TResult>(this Result<TSuccess, TFailure> result, Func<TFailure, Task<Result<TSuccess, TResult>>> bind)
 		{
 			if (bind == null) throw new ArgumentNullException(nameof(bind));
 
-			return !result.TryGetValue(out _, out var failure)
+			return !result.TryGetValue(out var success, out var failure)
 				? await bind.Invoke(failure)
-				: result;
+				: Result.Success<TSuccess, TResult>(success);
 		}
 
-		public static async Task<Result<TSuccess, TFailure>> BindOnFailureAsync<TSuccess, TFailure>(this Task<Result<TSuccess, TFailure>> result, Func<TFailure, Task<Result<TSuccess, TFailure>>> bind)
+		public static async Task<Result<TSuccess, TResult>> BindOnFailureAsync<TSuccess, TFailure, TResult>(this Task<Result<TSuccess, TFailure>> result, Func<TFailure, Task<Result<TSuccess, TResult>>> bind)
 			=> await (await result).BindOnFailureAsync(bind);
 
 		public static async Task<Result<TSuccess, TFailure>> DoAsync<TSuccess, TFailure>(this Result<TSuccess, TFailure> result, Func<TSuccess, Task> onSuccess, Func<TFailure, Task> onFailure)

--- a/Functional.Primitives.Extensions/ResultAsyncExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultAsyncExtensions.cs
@@ -79,6 +79,17 @@ namespace Functional
 		public static async Task<Result<TResult, TFailure>> BindAsync<TSuccess, TFailure, TResult>(this Task<Result<TSuccess, TFailure>> result, Func<TSuccess, Task<Result<TResult, TFailure>>> bind)
 			=> await (await result).BindAsync(bind);
 
+		[Obsolete]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static async Task<Result<TSuccess, TFailure>> BindOnFailureAsync<TSuccess, TFailure>(Result<TSuccess, TFailure> result, Func<TFailure, Task<Result<TSuccess, TFailure>>> bind)
+		{
+			if (bind == null) throw new ArgumentNullException(nameof(bind));
+
+			return !result.TryGetValue(out _, out var failure)
+				? await bind.Invoke(failure)
+				: result;
+		}
+
 		public static async Task<Result<TSuccess, TResult>> BindOnFailureAsync<TSuccess, TFailure, TResult>(this Result<TSuccess, TFailure> result, Func<TFailure, Task<Result<TSuccess, TResult>>> bind)
 		{
 			if (bind == null) throw new ArgumentNullException(nameof(bind));
@@ -87,6 +98,11 @@ namespace Functional
 				? await bind.Invoke(failure)
 				: Result.Success<TSuccess, TResult>(success);
 		}
+
+		[Obsolete]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static async Task<Result<TSuccess, TFailure>> BindOnFailureAsync<TSuccess, TFailure>(Task<Result<TSuccess, TFailure>> result, Func<TFailure, Task<Result<TSuccess, TFailure>>> bind)
+			=> await BindOnFailureAsync<TSuccess, TFailure>(await result, bind);
 
 		public static async Task<Result<TSuccess, TResult>> BindOnFailureAsync<TSuccess, TFailure, TResult>(this Task<Result<TSuccess, TFailure>> result, Func<TFailure, Task<Result<TSuccess, TResult>>> bind)
 			=> await (await result).BindOnFailureAsync(bind);

--- a/Functional.Primitives.Extensions/ResultExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultExtensions.cs
@@ -86,6 +86,17 @@ namespace Functional
 		public static async Task<Result<TResult, TFailure>> Bind<TSuccess, TFailure, TResult>(this Task<Result<TSuccess, TFailure>> result, Func<TSuccess, Result<TResult, TFailure>> bind)
 			=> (await result).Bind(bind);
 
+		[Obsolete]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static Result<TSuccess, TFailure> BindOnFailure<TSuccess, TFailure>(Result<TSuccess, TFailure> result, Func<TFailure, Result<TSuccess, TFailure>> bind)
+		{
+			if (bind == null) throw new ArgumentNullException(nameof(bind));
+
+			return !result.TryGetValue(out _, out var failure)
+				? bind.Invoke(failure)
+				: result;
+		}
+
 		public static Result<TSuccess, TResult> BindOnFailure<TSuccess, TFailure, TResult>(this Result<TSuccess, TFailure> result, Func<TFailure, Result<TSuccess, TResult>> bind)
 		{
 			if (bind == null) throw new ArgumentNullException(nameof(bind));
@@ -94,6 +105,11 @@ namespace Functional
 				? bind.Invoke(failure)
 				: Result.Success<TSuccess, TResult>(success);
 		}
+
+		[Obsolete]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static async Task<Result<TSuccess, TFailure>> BindOnFailure<TSuccess, TFailure>(Task<Result<TSuccess, TFailure>> result, Func<TFailure, Result<TSuccess, TFailure>> bind)
+			=> BindOnFailure<TSuccess, TFailure>(await result, bind);
 
 		public static async Task<Result<TSuccess, TResult>> BindOnFailure<TSuccess, TFailure, TResult>(this Task<Result<TSuccess, TFailure>> result, Func<TFailure, Result<TSuccess, TResult>> bind)
 			=> (await result).BindOnFailure(bind);

--- a/Functional.Primitives.Extensions/ResultExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultExtensions.cs
@@ -86,16 +86,16 @@ namespace Functional
 		public static async Task<Result<TResult, TFailure>> Bind<TSuccess, TFailure, TResult>(this Task<Result<TSuccess, TFailure>> result, Func<TSuccess, Result<TResult, TFailure>> bind)
 			=> (await result).Bind(bind);
 
-		public static Result<TSuccess, TFailure> BindOnFailure<TSuccess, TFailure>(this Result<TSuccess, TFailure> result, Func<TFailure, Result<TSuccess, TFailure>> bind)
+		public static Result<TSuccess, TResult> BindOnFailure<TSuccess, TFailure, TResult>(this Result<TSuccess, TFailure> result, Func<TFailure, Result<TSuccess, TResult>> bind)
 		{
 			if (bind == null) throw new ArgumentNullException(nameof(bind));
 
-			return !result.TryGetValue(out _, out var failure)
+			return !result.TryGetValue(out var success, out var failure)
 				? bind.Invoke(failure)
-				: result;
+				: Result.Success<TSuccess, TResult>(success);
 		}
 
-		public static async Task<Result<TSuccess, TFailure>> BindOnFailure<TSuccess, TFailure>(this Task<Result<TSuccess, TFailure>> result, Func<TFailure, Result<TSuccess, TFailure>> bind)
+		public static async Task<Result<TSuccess, TResult>> BindOnFailure<TSuccess, TFailure, TResult>(this Task<Result<TSuccess, TFailure>> result, Func<TFailure, Result<TSuccess, TResult>> bind)
 			=> (await result).BindOnFailure(bind);
 
 		public static Result<TSuccess, TFailure> Do<TSuccess, TFailure>(this Result<TSuccess, TFailure> result, Action<TSuccess> onSuccess, Action<TFailure> onFailure)

--- a/Functional.Tests/Results/ResultAsyncExtensionsTests.cs
+++ b/Functional.Tests/Results/ResultAsyncExtensionsTests.cs
@@ -348,7 +348,7 @@ namespace Functional.Tests.Results
 			[Fact]
 			public Task BindOnFailureSuccess()
 				=> Value
-					.BindOnFailureAsync(i => Task.FromResult(Result.Success<int, string>(3)))
+					.BindOnFailureAsync(i => Task.FromResult(Result.Success<int, bool>(3)))
 					.AssertSuccess()
 					.Should()
 					.Be(3);
@@ -356,10 +356,10 @@ namespace Functional.Tests.Results
 			[Fact]
 			public Task BindOnFailureFailure()
 				=> Value
-					.BindOnFailureAsync(i => Task.FromResult(Result.Failure<int, string>("123")))
+					.BindOnFailureAsync(i => Task.FromResult(Result.Failure<int, bool>(false)))
 					.AssertFailure()
 					.Should()
-					.Be("123");
+					.BeFalse();
 
 			[Fact]
 			public async Task DoWithOneParameter()

--- a/Functional.Tests/Results/ResultExtensionsTests.cs
+++ b/Functional.Tests/Results/ResultExtensionsTests.cs
@@ -411,7 +411,7 @@ namespace Functional.Tests.Results
 			[Fact]
 			public void BindOnFailureSuccess()
 				=> Value
-					.BindOnFailure(i => Result.Success<int, string>(3))
+					.BindOnFailure(i => Result.Success<int, bool>(3))
 					.AssertSuccess()
 					.Should()
 					.Be(3);
@@ -419,10 +419,10 @@ namespace Functional.Tests.Results
 			[Fact]
 			public void BindOnFailureFailure()
 				=> Value
-					.BindOnFailure(i => Result.Failure<int, string>("123"))
+					.BindOnFailure(i => Result.Failure<int, bool>(false))
 					.AssertFailure()
 					.Should()
-					.Be("123");
+					.Be(false);
 
 			[Fact]
 			public void DoWithOneParameter()


### PR DESCRIPTION
Resolves #102 

The change wasn't breaking as far as the tests are concerned, I only updated them to demonstrate the `TFailure` -> `TResult` type mapping, however this is a breaking change in the strictest sense (ie: if generic parameters are explicit). @JohannesMoersch thoughts on what the new version number should be?

Because the change is a strict generalization of the existing method, I chose to modify the existing tests rather than introduce new ones.

I also left `BindIfFailure()` alone, as it's already marked as obsolete.