### PR TITLE
add BindToResult extension method for Option<T>

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Authors>Johannes Moersch + contributors</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © 2020 Johannes Moersch</Copyright>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/Functional.Primitives.Extensions/OptionExtensions.cs
+++ b/Functional.Primitives.Extensions/OptionExtensions.cs
@@ -112,6 +112,14 @@ namespace Functional
 		public static async Task<Result<TValue, TFailure>> ToResult<TValue, TFailure>(this Task<Option<TValue>> option, Func<TFailure> failureFactory)
 			=> (await option).ToResult(failureFactory);
 
+		public static Result<Option<TValue>, TFailure> BindToResult<TValue, TFailure>(this Option<TValue> option)
+			=> Result.Success<Option<TValue>, TFailure>(option.TryGetValue(out var some)
+				? Option.Some(some)
+				: Option.None<TValue>());
+
+		public static async Task<Result<Option<TValue>, TFailure>> BindToResult<TValue, TFailure>(this Task<Option<TValue>> option)
+			=> (await option).BindToResult<TValue, TFailure>();
+
 		public static Option<TValue> Do<TValue>(this Option<TValue> option, Action<TValue> doWhenSome, Action doWhenNone)
 		{
 			if (doWhenSome == null)

--- a/Functional.Tests/Options/OptionExtensionsTests.cs
+++ b/Functional.Tests/Options/OptionExtensionsTests.cs
@@ -126,6 +126,15 @@ namespace Functional.Tests.Options
 					.Be(10);
 
 			[Fact]
+			public void BindToResult()
+				=> Value
+					.BindToResult<int, string>()
+					.AssertSuccess()
+					.AssertSome()
+					.Should()
+					.Be(10);
+
+			[Fact]
 			public void DoWithOneParameter()
 			{
 				bool some = false;
@@ -279,6 +288,15 @@ namespace Functional.Tests.Options
 					.Be(IntValue);
 
 			[Fact]
+			public Task BindToResult()
+				=> Value
+					.BindToResult<int, string>()
+					.AssertSuccess()
+					.AssertSome()
+					.Should()
+					.Be(IntValue);
+
+			[Fact]
 			public async Task DoWithOneParameter()
 			{
 				bool some = false;
@@ -418,6 +436,13 @@ namespace Functional.Tests.Options
 					.AssertFailure()
 					.Should()
 					.Be("abc");
+
+			[Fact]
+			public void BindToResult()
+				=> Value
+					.BindToResult<int, string>()
+					.AssertSuccess()
+					.AssertNone();
 
 			[Fact]
 			public void DoWithOneParameter()
@@ -566,6 +591,13 @@ namespace Functional.Tests.Options
 					.AssertFailure()
 					.Should()
 					.Be("abc");
+
+			[Fact]
+			public Task BindToResult()
+				=> Value
+					.BindToResult<int, string>()
+					.AssertSuccess()
+					.AssertNone();
 
 			[Fact]
 			public async Task DoWithOneParameter()

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ If `Some`, this extension will return a `Success` result with the value, and if 
 Result<int, string> result = Option.Some<int>(100).ToResult(() => "Failure Message"); // Returns Result<int, string> with a success value of 100
 Result<int, string> result = Option.None<int>().ToResult(() => "Failure Message"); // Returns Result<int, string> with a failure value of "Failure Message"
 ```
+#### BindToResult
+If `Some`, this extension will return a `Success` result with the value, and if `None` it will a `Success` result with no value.
+```csharp
+Result<Option<int>, string> result = Option.Some<int>(100).BindToResult<int, string>(); // Returns Result<Option<int>, string> with a success value of Option<int> with some a value of 100
+Result<Option<int>, string> result = Option.None<int>().BindToResult<int, string>(); // Returns Result<Option<int>, string> with a success value of Option<int> with no value
+```
 #### ToEnumerable
 If `Some`, this extension method will return an `IEnumerable<T>` containing a single item: the value. If `None`, it will return an empty `IEnumerable<T>`.
 ``` csharp


### PR DESCRIPTION
#35 

To be honest, I'm not happy with the current syntax...  I'm open to ideas on how to get type inference working and avoid having to specify the two type parameters (`TValue`, `TFailure`) explicitly.