### PR TITLE
deprecate Option.ValueOrNull

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Authors>Johannes Moersch + contributors</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © 2020 Johannes Moersch</Copyright>
-    <Version>2.4.0</Version>
+    <Version>2.4.2</Version>
   </PropertyGroup>
 
 </Project>

--- a/Functional.Primitives.Extensions/ObsoleteOptionExtensions.cs
+++ b/Functional.Primitives.Extensions/ObsoleteOptionExtensions.cs
@@ -37,6 +37,18 @@ namespace Functional
 		[Obsolete("Please also handle none explicitly.")]
 		public static Task Apply<TValue>(this Task<Option<TValue>> option, Action<TValue> apply)
 			=> option.Do(apply);
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("Please use .ToNullable() instead.")]
+		public static TValue? ValueOrNull<TValue>(this Option<TValue> option)
+			where TValue : struct
+			=> option.TryGetValue(out var some) ? (TValue?)some : null;
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("Please use .ToNullable() instead.")]
+		public static async Task<TValue?> ValueOrNull<TValue>(this Task<Option<TValue>> option)
+			where TValue : struct
+			=> (await option).ValueOrNull();
 	}
 
 	public static partial class OptionAsyncExtensions

--- a/Functional.Primitives.Extensions/OptionExtensions.cs
+++ b/Functional.Primitives.Extensions/OptionExtensions.cs
@@ -50,14 +50,6 @@ namespace Functional
 		public static async Task<TValue> ValueOrDefault<TValue>(this Task<Option<TValue>> option, TValue defaultValue = default)
 			=> (await option).ValueOrDefault(defaultValue);
 
-		public static TValue? ValueOrNull<TValue>(this Option<TValue> option)
-			where TValue : struct
-			=> option.TryGetValue(out var some) ? (TValue?)some : null;
-
-		public static async Task<TValue?> ValueOrNull<TValue>(this Task<Option<TValue>> option)
-			where TValue : struct
-			=> (await option).ValueOrNull();
-
 		public static IEnumerable<TValue> ValueOrEmpty<TValue>(this Option<IEnumerable<TValue>> option)
 			=> option.ValueOrDefault(Enumerable.Empty<TValue>());
 

--- a/Functional.Tests/Options/OptionExtensionsTests.cs
+++ b/Functional.Tests/Options/OptionExtensionsTests.cs
@@ -52,13 +52,6 @@ namespace Functional.Tests.Options
 					.Be(10);
 
 			[Fact]
-			public void ValueOrNull()
-				=> Value
-					.ValueOrNull()
-					.Should()
-					.Be(IntValue);
-
-			[Fact]
 			public void BindOnNone()
 				=> Value
 					.BindOnNone(() => Option.Some(20))
@@ -216,13 +209,6 @@ namespace Functional.Tests.Options
 					.Be(10);
 
 			[Fact]
-			public Task ValueOrNull()
-				=> Value
-					.ValueOrNull()
-					.Should()
-					.Be(IntValue);
-
-			[Fact]
 			public void ValueOrEmpty()
 				=> Option.None<IEnumerable<int>>()
 					.ValueOrEmpty()
@@ -362,13 +348,6 @@ namespace Functional.Tests.Options
 					.ValueOrDefault(5)
 					.Should()
 					.Be(5);
-
-			[Fact]
-			public void ValueOrNull()
-				=> Value
-					.ValueOrNull()
-					.Should()
-					.BeNull();
 
 			[Fact]
 			public void BindOnNone()
@@ -514,13 +493,6 @@ namespace Functional.Tests.Options
 					.ValueOrDefault(5)
 					.Should()
 					.Be(5);
-
-			[Fact]
-			public Task ValueOrNull()
-				=> Value
-					.ValueOrNull()
-					.Should()
-					.BeNull();
 
 			[Fact]
 			public Task OfTypeMatching()

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Option<int> value = Option.None<int>().BindOnNone(() => Option.None<int>()); // 
 #### ToNullable
 This extension only works on value types. If `Some`, this extension will return the value, and if `None` it will return null.
 ```csharp
-int? value = Option.Some<int>(100).ValueOrNull(); // Returns 100
-int? value = Option.None<int>().ValueOrNull(); // Returns null
+int? value = Option.Some<int>(100).ToNullable(); // Returns 100
+int? value = Option.None<int>().ToNullable(); // Returns null
 ```
 #### OfType
 This extension only works on `Option<object>`. If `Some` and the value is of the specified type, then a typed Option is returned. Otherwise `None` is returned.


### PR DESCRIPTION
Closes #71 .  #103 should be merged in first though due to the version numbers used.