### PR TITLE
Convenience extension methods for Option<string>

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Authors>Johannes Moersch + contributors</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © 2020 Johannes Moersch</Copyright>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Authors>Johannes Moersch + contributors</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © 2020 Johannes Moersch</Copyright>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Authors>Johannes Moersch + contributors</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © 2020 Johannes Moersch</Copyright>
-    <Version>2.9.0</Version>
+    <Version>2.8.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/Functional.Primitives.Extensions/OptionOfStringExtensions.cs
+++ b/Functional.Primitives.Extensions/OptionOfStringExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Functional
+{
+	public static class OptionOfStringExtensions
+	{
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static Option<string> WhereNonEmpty(this Option<string> option)
+			=> option.Where(s => !string.IsNullOrEmpty(s));
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static Option<string> WhereNonWhiteSpace(this Option<string> option)
+			=> option.Where(s => !string.IsNullOrWhiteSpace(s));
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static async Task<Option<string>> WhereNonEmpty(this Task<Option<string>> option)
+			=> (await option).WhereNonEmpty();
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static async Task<Option<string>> WhereNonWhiteSpace(this Task<Option<string>> option)
+			=> (await option).WhereNonWhiteSpace();
+	}
+}

--- a/Functional.Primitives.Extensions/OptionOfStringExtensions.cs
+++ b/Functional.Primitives.Extensions/OptionOfStringExtensions.cs
@@ -1,17 +1,22 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace Functional
 {
 	public static class OptionOfStringExtensions
 	{
+		private static readonly Func<string, bool> _whereNonEmptyFunc = s => !string.IsNullOrEmpty(s);
+		private static readonly Func<string, bool> _whereNonWhiteSpaceFunc = s => !string.IsNullOrWhiteSpace(s);
+
+
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static Option<string> WhereNonEmpty(this Option<string> option)
-			=> option.Where(s => !string.IsNullOrEmpty(s));
+			=> option.Where(_whereNonEmptyFunc);
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static Option<string> WhereNonWhiteSpace(this Option<string> option)
-			=> option.Where(s => !string.IsNullOrWhiteSpace(s));
+			=> option.Where(_whereNonWhiteSpaceFunc);
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static async Task<Option<string>> WhereNonEmpty(this Task<Option<string>> option)

--- a/Functional.Tests/Options/OptionOfStringExtensionsTests.cs
+++ b/Functional.Tests/Options/OptionOfStringExtensionsTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Threading.Tasks;
+using AutoFixture.Xunit2;
+using FluentAssertions;
+using Xunit;
+
+namespace Functional.Tests.Options
+{
+	public class OptionOfStringExtensionsTests
+	{
+		public class Sync
+		{
+			[Theory]
+			[InlineData(null)]
+			[InlineData("")]
+			public void ReturnsNoneForEmptyString(string value)
+				=> Option.FromNullable(value)
+					.WhereNonEmpty()
+					.AssertNone();
+
+			[Theory, AutoData]
+			public void ReturnsSomeForNonEmptyString(string value)
+				=> Option.FromNullable(value)
+					.WhereNonEmpty()
+					.AssertSome()
+					.Should()
+					.Be(value);
+
+			[Theory]
+			[InlineData(null)]
+			[InlineData("")]
+			[InlineData(" ")]
+			[InlineData("     ")]
+			[InlineData("\t")]
+			[InlineData("\n")]
+			public void ReturnsNoneForWhiteSpaceString(string value)
+				=> Option.FromNullable(value)
+					.WhereNonWhiteSpace()
+					.AssertNone();
+
+			[Theory, AutoData]
+			public void ReturnsSomeForNonWhiteSpaceString(string value)
+				=> Option.FromNullable(value)
+					.WhereNonEmpty()
+					.AssertSome()
+					.Should()
+					.Be(value);
+		}
+
+		public class Async
+		{
+			[Theory]
+			[InlineData(null)]
+			[InlineData("")]
+			public async Task ReturnsNoneForEmptyString(string value)
+				=> await Task.FromResult(Option.FromNullable(value))
+					.WhereNonEmpty()
+					.AssertNone();
+
+			[Theory, AutoData]
+			public async Task ReturnsSomeForNonEmptyString(string value)
+				=> await Task.FromResult(Option.FromNullable(value))
+					.WhereNonEmpty()
+					.AssertSome()
+					.Should()
+					.Be(value);
+
+			[Theory]
+			[InlineData(null)]
+			[InlineData("")]
+			[InlineData(" ")]
+			[InlineData("     ")]
+			[InlineData("\t")]
+			[InlineData("\n")]
+			public async Task ReturnsNoneForWhiteSpaceString(string value)
+				=> await Task.FromResult(Option.FromNullable(value))
+					.WhereNonWhiteSpace()
+					.AssertNone();
+
+			[Theory, AutoData]
+			public async Task ReturnsSomeForNonWhiteSpaceString(string value)
+				=> await Task.FromResult(Option.FromNullable(value))
+					.WhereNonEmpty()
+					.AssertSome()
+					.Should()
+					.Be(value);
+		}
+	}
+}


### PR DESCRIPTION
Closes #113 

Adds `WhereNonEmpty()` and `WhereNonWhiteSpace()` extension methods to `Option<string>`