### PR TITLE
WhereOnSome for Result<Option<TSuccess>, TFailure> types

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Authors>Johannes Moersch + contributors</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © 2020 Johannes Moersch</Copyright>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/Functional.Primitives.Extensions/ResultOptionAsyncExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultOptionAsyncExtensions.cs
@@ -135,5 +135,23 @@ namespace Functional
 
 		public static async Task<Result<Option<TSuccess>, TFailure>> DoOnSomeAsync<TSuccess, TFailure>(this Task<Result<Option<TSuccess>, TFailure>> result, Func<TSuccess, Task> onSuccessSome)
 			=> await (await result).DoOnSomeAsync(onSuccessSome);
+
+		public static async Task<Result<Option<TSuccess>, TFailure>> WhereOnSomeAsync<TSuccess, TFailure>(this Result<Option<TSuccess>, TFailure> result, Func<TSuccess, Task<bool>> predicate, Func<TSuccess, TFailure> failureFactory)
+		{
+			if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+			if (failureFactory == null) throw new ArgumentNullException(nameof(failureFactory));
+
+			if (result.TryGetValue(out var success, out var failure) && success.TryGetValue(out var some))
+			{
+				return await predicate.Invoke(some)
+					? result
+					: Result.Failure<Option<TSuccess>, TFailure>(failureFactory.Invoke(some));
+			}
+
+			return result;
+		}
+
+		public static async Task<Result<Option<TSuccess>, TFailure>> WhereOnSomeAsync<TSuccess, TFailure>(this Task<Result<Option<TSuccess>, TFailure>> result, Func<TSuccess, Task<bool>> predicate, Func<TSuccess, TFailure> failureFactory)
+			=> await (await result).WhereOnSomeAsync(predicate, failureFactory);
 	}
 }

--- a/Functional.Primitives.Extensions/ResultOptionExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultOptionExtensions.cs
@@ -167,6 +167,18 @@ namespace Functional
 			return Result.Success<Option<TSuccess>, TFailure>(Option.None<TSuccess>());
 		}
 
+		public static Result<Option<TSuccess>, TFailure> WhereOnSome<TSuccess, TFailure>(this Result<Option<TSuccess>, TFailure> source, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> failureFactory)
+		{
+			return source.Where(
+				x => x.Match(predicate.Invoke, () => true),
+				x => x.Match(failureFactory, () => throw new InvalidOperationException("")));
+		}
+
+		public static async Task<Result<Option<TSuccess>, TFailure>> WhereOnSome<TSuccess, TFailure>(this Task<Result<Option<TSuccess>, TFailure>> source, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> failureFactory)
+		{
+			return (await source).WhereOnSome(predicate, failureFactory);
+		}
+
 		public static async Task<Result<Option<TSuccess>, TFailure>> Evert<TSuccess, TFailure>(this Task<Option<Result<TSuccess, TFailure>>> source)
 			=> (await source).Evert();
 	}

--- a/Functional.Primitives.Extensions/ResultOptionExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultOptionExtensions.cs
@@ -155,6 +155,24 @@ namespace Functional
 		public static async Task<Result<Option<TSuccess>, TFailure>> DoOnSome<TSuccess, TFailure>(this Task<Result<Option<TSuccess>, TFailure>> result, Action<TSuccess> onSuccessSome)
 			=> (await result).DoOnSome(onSuccessSome);
 
+		public static Result<Option<TSuccess>, TFailure> WhereOnSome<TSuccess, TFailure>(this Result<Option<TSuccess>, TFailure> result, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> failureFactory)
+		{
+			if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+			if (failureFactory == null) throw new ArgumentNullException(nameof(failureFactory));
+
+			if (result.TryGetValue(out var success, out var failure) && success.TryGetValue(out var some))
+			{
+				return predicate.Invoke(some)
+					? result
+					: Result.Failure<Option<TSuccess>, TFailure>(failureFactory.Invoke(some));
+			}
+
+			return result;
+		}
+
+		public static async Task<Result<Option<TSuccess>, TFailure>> WhereOnSome<TSuccess, TFailure>(this Task<Result<Option<TSuccess>, TFailure>> result, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> failureFactory)
+			=> (await result).WhereOnSome(predicate, failureFactory);
+
 		public static Result<Option<TSuccess>, TFailure> Evert<TSuccess, TFailure>(this Option<Result<TSuccess, TFailure>> source)
 		{
 			if (source.TryGetValue(out var some))
@@ -165,18 +183,6 @@ namespace Functional
 			}
 
 			return Result.Success<Option<TSuccess>, TFailure>(Option.None<TSuccess>());
-		}
-
-		public static Result<Option<TSuccess>, TFailure> WhereOnSome<TSuccess, TFailure>(this Result<Option<TSuccess>, TFailure> source, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> failureFactory)
-		{
-			return source.Where(
-				x => x.Match(predicate.Invoke, () => true),
-				x => x.Match(failureFactory, () => throw new InvalidOperationException("")));
-		}
-
-		public static async Task<Result<Option<TSuccess>, TFailure>> WhereOnSome<TSuccess, TFailure>(this Task<Result<Option<TSuccess>, TFailure>> source, Func<TSuccess, bool> predicate, Func<TSuccess, TFailure> failureFactory)
-		{
-			return (await source).WhereOnSome(predicate, failureFactory);
 		}
 
 		public static async Task<Result<Option<TSuccess>, TFailure>> Evert<TSuccess, TFailure>(this Task<Option<Result<TSuccess, TFailure>>> source)

--- a/Functional.Tests/Results/ResultOptionExtensionsTests.cs
+++ b/Functional.Tests/Results/ResultOptionExtensionsTests.cs
@@ -1913,6 +1913,48 @@ namespace Functional.Tests.Results
 				}
 			}
 
+			public class WhenWhereOnSomeAsync
+			{
+				private const int SUCCESS = 1337;
+				private const string FAILURE = "error";
+
+				[Fact]
+				public async Task ShouldMapOptionSomeSatisfyingPredicateToOptionSome()
+					=> await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(SUCCESS)))
+						.WhereOnSomeAsync(i => Task.FromResult(i == SUCCESS), i => FAILURE)
+						.AssertSuccess()
+						.AssertSome()
+						.Should()
+						.Be(SUCCESS);
+
+				[Fact]
+				public async Task ShouldMapOptionNoneToOptionNone()
+					=> await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+						.WhereOnSomeAsync(i => Task.FromResult(i == SUCCESS), i => FAILURE)
+						.AssertSuccess()
+						.AssertNone();
+
+				[Fact]
+				public async Task ShouldMapOptionSomeNotSatisfyingPredicateToFailure()
+					=> await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(SUCCESS)))
+						.WhereOnSomeAsync(i => Task.FromResult(i != SUCCESS), i => FAILURE)
+						.AssertFailure()
+						.Should()
+						.Be(FAILURE);
+
+				[Fact]
+				public async Task ShouldMapFailureToFailure()
+				{
+					const string EXPECTED = "TEST";
+
+					await Task.FromResult(Result.Failure<Option<int>, string>(EXPECTED))
+						.WhereOnSomeAsync(i => Task.FromResult(i != SUCCESS), i => FAILURE)
+						.AssertFailure()
+						.Should()
+						.Be(EXPECTED);
+				}
+			}
+
 			public class AndEvert
 			{
 				private const int SUCCESS = 1337;

--- a/Functional.Tests/Results/ResultOptionExtensionsTests.cs
+++ b/Functional.Tests/Results/ResultOptionExtensionsTests.cs
@@ -1152,6 +1152,48 @@ namespace Functional.Tests.Results
 				}
 			}
 
+			public class AndWhereOnSome
+			{
+				private const int SUCCESS = 1337;
+				private const string FAILURE = "error";
+
+				[Fact]
+				public void ShouldMapOptionSomeSatisfyingPredicateToOptionSome()
+					=> Result.Success<Option<int>, string>(Option.Some(SUCCESS))
+						.WhereOnSome(i => i == SUCCESS, i => FAILURE)
+						.AssertSuccess()
+						.AssertSome()
+						.Should()
+						.Be(SUCCESS);
+
+				[Fact]
+				public void ShouldMapOptionNoneToOptionNone()
+					=> Result.Success<Option<int>, string>(Option.None<int>())
+						.WhereOnSome(i => i == SUCCESS, i => FAILURE)
+						.AssertSuccess()
+						.AssertNone();
+
+				[Fact]
+				public void ShouldMapOptionSomeNotSatisfyingPredicateToFailure()
+					=> Result.Success<Option<int>, string>(Option.Some(SUCCESS))
+						.WhereOnSome(i => i != SUCCESS, i => FAILURE)
+						.AssertFailure()
+						.Should()
+						.Be(FAILURE);
+
+				[Fact]
+				public void ShouldMapFailureToFailure()
+				{
+					const string EXPECTED = "TEST";
+
+					Result.Failure<Option<int>, string>(EXPECTED)
+						.WhereOnSome(i => i != SUCCESS, i => FAILURE)
+						.AssertFailure()
+						.Should()
+						.Be(EXPECTED);
+				}
+			}
+
 			public class AndEvert
 			{
 				private const int SUCCESS = 1337;
@@ -1826,6 +1868,48 @@ namespace Functional.Tests.Results
 						return Task.CompletedTask;
 					});
 					methodCalled.Should().BeFalse();
+				}
+			}
+
+			public class WhenWhereOnSome
+			{
+				private const int SUCCESS = 1337;
+				private const string FAILURE = "error";
+
+				[Fact]
+				public async Task ShouldMapOptionSomeSatisfyingPredicateToOptionSome()
+					=> await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(SUCCESS)))
+						.WhereOnSome(i => i == SUCCESS, i => FAILURE)
+						.AssertSuccess()
+						.AssertSome()
+						.Should()
+						.Be(SUCCESS);
+
+				[Fact]
+				public async Task ShouldMapOptionNoneToOptionNone()
+					=> await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>()))
+						.WhereOnSome(i => i == SUCCESS, i => FAILURE)
+						.AssertSuccess()
+						.AssertNone();
+
+				[Fact]
+				public async Task ShouldMapOptionSomeNotSatisfyingPredicateToFailure()
+					=> await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(SUCCESS)))
+						.WhereOnSome(i => i != SUCCESS, i => FAILURE)
+						.AssertFailure()
+						.Should()
+						.Be(FAILURE);
+
+				[Fact]
+				public async Task ShouldMapFailureToFailure()
+				{
+					const string EXPECTED = "TEST";
+
+					await Task.FromResult(Result.Failure<Option<int>, string>(EXPECTED))
+						.WhereOnSome(i => i != SUCCESS, i => FAILURE)
+						.AssertFailure()
+						.Should()
+						.Be(EXPECTED);
 				}
 			}
 

--- a/doc/result.md
+++ b/doc/result.md
@@ -284,7 +284,7 @@ string returnValue = Result.Failure<Option<int>, Exception>(new Exception("ERROR
 
 ``` csharp
 // 'returnValue' is "1337"
-string value = Result.Success<Option<int>, Exception>(Option.Some(1337)).Match(
+string returnValue = Result.Success<Option<int>, Exception>(Option.Some(1337)).Match(
     i => i.ToString(),
     () => "no value",
     exception => exception.Message);
@@ -419,7 +419,7 @@ Result<Option<int>, string> result = Result.Failure<Option<int>, string>("Failur
 ```
 
 ```csharp
-// bind to functions producing Result<Option<T>>, TFailure>
+// Bind to functions producing Result<Option<T>>, TFailure>
 
 // Returns Result<Option<float>, string> with a success value of Option.Some(200f)
 Result<Option<int>, string> result = Result.Success<Option<int>, string>(Option.Some(100)).BindOnNone(() => Result.Success<Option<float>, string>(Option.Some(i * 2f)));
@@ -435,6 +435,26 @@ Result<Option<int>, string> result = Result.Success<Option<int>, string>(Option.
 
 // Returns Result<Option<float>, string> with a failure value of "Failure"
 Result<Option<int>, string> result = Result.Failure<Option<int>, string>("Failure").BindOnNone(() => Result.Success<Option<float>, string>(Option.Some(i * 2f)));
+```
+
+### WhereOnSome
+
+If the input Result is `Success` and holds `Some`, this extension will invoke the first delegate parameter; then, if `true` is returned the extension will return `Success` of the input success value. If `false` is returned from the first delegate parameter, the extension will return a `Failure` Result with the failure value produced by the second delegate parameter. If the input Result is `Success` and holds `None` or if the input Result is a `Failure` the extension will return the unmodified input.
+
+```csharp
+// Returns Result<Option<int>, string> with a success value of Option.Some(1337)
+Result<Option<int>, string> result = Result.Success<Option<int>, string>(Option.Some(1337)).WhereOnSome(i => true, i => "Failure");
+
+// Returns Result<Option<int>, string> with a failure value of "Failure"
+Result<Option<int>, string> result = Result.Success<Option<int>, string>(Option.Some(1337)).WhereOnSome(i => false, i => "Failure");
+
+// Returns original result (Result<Option<int>, string> with a success value of Option.None<int>())
+Result<Option<int>, string> result = Result.Success<Option<int>, string>(Option.None<int>()).WhereOnSome(i => true, i => "Failure");
+Result<Option<int>, string> result = Result.Success<Option<int>, string>(Option.None<int>()).WhereOnSome(i => false, i => "Failure");
+
+// Returns original result (Result<Option<int>, string> with a failure value of "Original failure")
+Result<Option<int>, string> result = Result.Failure<Option<int>, string>("Original failure").WhereOnSome(i => true, i => "Failure");
+Result<Option<int>, string> result = Result.Failure<Option<int>, string>("Original failure").WhereOnSome(i => false, i => "Failure");
 ```
 
 ### DoOnSome


### PR DESCRIPTION
Adds `WhereOnSome` / `WhereOnSomeAsync` extension methods for `Result<Option<TSuccess>, TFailure>` types

Example usage:
- entity found and satisfies predicate => success holding `Some<T>` (input unmodified)
- entity found but does not satisfy predicate => failure produced by extension method
- entity not found => success holding `None<T>` (input unmodified)
- failure => failure (input unmodified)