### PR TITLE
Result<Option<T>, TFailure>.Apply

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Authors>Johannes Moersch + contributors</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © 2020 Johannes Moersch</Copyright>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/Functional.Primitives.Extensions/ResultOptionExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultOptionExtensions.cs
@@ -187,5 +187,31 @@ namespace Functional
 
 		public static async Task<Result<Option<TSuccess>, TFailure>> Evert<TSuccess, TFailure>(this Task<Option<Result<TSuccess, TFailure>>> source)
 			=> (await source).Evert();
+
+		public static void Apply<T, TFailure>(this Result<Option<T>, TFailure> result, Action<T> onSome, Action onNone, Action<TFailure> onFailure)
+		{
+			if (onSome == null) throw new ArgumentNullException(nameof(onSome));
+			if (onNone == null) throw new ArgumentNullException(nameof(onNone));
+			if (onFailure == null) throw new ArgumentNullException(nameof(onFailure));
+
+			if (result.TryGetValue(out var success, out var failure))
+			{
+				if (success.TryGetValue(out var some))
+				{
+					onSome.Invoke(some);
+				}
+				else
+				{
+					onNone.Invoke();
+				}
+			}
+			else
+			{
+				onFailure.Invoke(failure);
+			}
+		}
+
+		public static async Task Apply<T, TFailure>(this Task<Result<Option<T>, TFailure>> result, Action<T> onSome, Action onNone, Action<TFailure> onFailure)
+			=> (await result).Apply(onSome, onNone, onFailure);
 	}
 }

--- a/Functional.Tests/Results/ResultOptionExtensionsTests.cs
+++ b/Functional.Tests/Results/ResultOptionExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 
@@ -1223,6 +1224,54 @@ namespace Functional.Tests.Results
 						.Should()
 						.Be(FAILURE);
 			}
+
+			public class AndApply
+			{
+				[Fact]
+				public void ApplySome()
+					=> Result.Success<Option<int>, string>(Option.Some(1337)).Apply(
+						some => { },
+						() => throw new InvalidOperationException("Expected onSome branch to be executed but onNone branch was executed instead!"),
+						error => throw new InvalidOperationException("Expected onSome branch to be executed but onFailure branch was executed instead!"));
+
+				[Fact]
+				public void ApplyNone()
+					=> Result.Success<Option<int>, string>(Option.None<int>()).Apply(
+						some => throw new InvalidOperationException("Expected onNone branch to be executed but onSome branch was executed instead!"),
+						() => { },
+						error => throw new InvalidOperationException("Expected onNone branch to be executed but onFailure branch was executed instead!"));
+
+				[Fact]
+				public void ApplyFailure()
+					=> Result.Failure<Option<int>, string>("ERROR").Apply(
+						some => throw new InvalidOperationException("Expected onFailure branch to be executed but onSome branch was executed instead!"),
+						() => throw new InvalidOperationException("Expected onFailure branch to be executed but onNone branch was executed instead!"),
+						failure => { });
+			}
+
+			public class AndApplyAsync
+			{
+				[Fact]
+				public async Task ApplySome()
+					=> await Result.Success<Option<int>, string>(Option.Some(1337)).ApplyAsync(
+						some => Task.CompletedTask,
+						() => throw new InvalidOperationException("Expected onSome branch to be executed but onNone branch was executed instead!"),
+						error => throw new InvalidOperationException("Expected onSome branch to be executed but onFailure branch was executed instead!"));
+
+				[Fact]
+				public async Task ApplyNone()
+					=> await Result.Success<Option<int>, string>(Option.None<int>()).ApplyAsync(
+						some => throw new InvalidOperationException("Expected onNone branch to be executed but onSome branch was executed instead!"),
+						() => Task.CompletedTask,
+						error => throw new InvalidOperationException("Expected onNone branch to be executed but onFailure branch was executed instead!"));
+
+				[Fact]
+				public async Task ApplyFailure()
+					=> await Result.Failure<Option<int>, string>("ERROR").ApplyAsync(
+						some => throw new InvalidOperationException("Expected onFailure branch to be executed but onSome branch was executed instead!"),
+						() => throw new InvalidOperationException("Expected onFailure branch to be executed but onNone branch was executed instead!"),
+						failure => Task.CompletedTask);
+			}
 		}
 
 		public class WhenTaskOfResultOfOption
@@ -1983,6 +2032,54 @@ namespace Functional.Tests.Results
 						.AssertFailure()
 						.Should()
 						.Be(FAILURE);
+			}
+
+			public class AndApply
+			{
+				[Fact]
+				public async Task ApplySome()
+					=> await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).Apply(
+						some => { },
+						() => throw new InvalidOperationException("Expected onSome branch to be executed but onNone branch was executed instead!"),
+						error => throw new InvalidOperationException("Expected onSome branch to be executed but onFailure branch was executed instead!"));
+
+				[Fact]
+				public async Task ApplyNone()
+					=> await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).Apply(
+						some => throw new InvalidOperationException("Expected onNone branch to be executed but onSome branch was executed instead!"),
+						() => { },
+						error => throw new InvalidOperationException("Expected onNone branch to be executed but onFailure branch was executed instead!"));
+
+				[Fact]
+				public async Task ApplyFailure()
+					=> await Task.FromResult(Result.Failure<Option<int>, string>("ERROR")).Apply(
+						some => throw new InvalidOperationException("Expected onFailure branch to be executed but onSome branch was executed instead!"),
+						() => throw new InvalidOperationException("Expected onFailure branch to be executed but onNone branch was executed instead!"),
+						failure => { });
+			}
+
+			public class AndApplyAsync
+			{
+				[Fact]
+				public async Task ApplySome()
+					=> await Task.FromResult(Result.Success<Option<int>, string>(Option.Some(1337))).ApplyAsync(
+						some => Task.CompletedTask,
+						() => throw new InvalidOperationException("Expected onSome branch to be executed but onNone branch was executed instead!"),
+						error => throw new InvalidOperationException("Expected onSome branch to be executed but onFailure branch was executed instead!"));
+
+				[Fact]
+				public async Task ApplyNone()
+					=> await Task.FromResult(Result.Success<Option<int>, string>(Option.None<int>())).ApplyAsync(
+						some => throw new InvalidOperationException("Expected onNone branch to be executed but onSome branch was executed instead!"),
+						() => Task.CompletedTask,
+						error => throw new InvalidOperationException("Expected onNone branch to be executed but onFailure branch was executed instead!"));
+
+				[Fact]
+				public async Task ApplyFailure()
+					=> await Task.FromResult(Result.Failure<Option<int>, string>("ERROR")).ApplyAsync(
+						some => throw new InvalidOperationException("Expected onFailure branch to be executed but onSome branch was executed instead!"),
+						() => throw new InvalidOperationException("Expected onFailure branch to be executed but onNone branch was executed instead!"),
+						failure => Task.CompletedTask);
 			}
 		}
 	}

--- a/doc/result.md
+++ b/doc/result.md
@@ -487,6 +487,48 @@ Result.Success<Option<int>, string>(Option.None<int>()).ApplyOnSome(i => Console
 Result.Failure<Option<int>, string>("Failure").ApplyOnSome(i => Console.WriteLine(i));
 ```
 
+### Apply (Overload)
+
+This extension method reduces noise caused by using two `Apply` actions: one for the Result and one for the contained Option.  It exists purely for convenience.  The following two code blocks are equivalent.
+
+``` csharp
+// "1337" is printed to the console
+string returnValue = Result.Success<Option<int>, Exception>(Option.Some(1337)).Apply(
+    option => option.Apply(i => Console.WriteLine(i.ToString()), () => Console.WriteLine("no value")),
+    exception => Console.WriteLine(exception.Message));
+
+// "no value" is printed to the console
+string returnValue = Result.Success<Option<int>, Exception>(Option.None<int>()).Apply(
+    option => option.Apply(i => Console.WriteLine(i.ToString()), () => Console.WriteLine("no value")),
+    exception => Console.WriteLine(exception.Message));
+
+// "ERROR" is printed to the console
+string returnValue = Result.Failure<Option<int>, Exception>(new Exception("ERROR")).Apply(
+    option => option.Apply(i => Console.WriteLine(i.ToString()), () => Console.WriteLine("no value")),
+    exception => Console.WriteLine(exception.Message));
+```
+
+``` csharp
+// "1337" is printed to the console
+string returnValue = Result.Success<Option<int>, Exception>(Option.Some(1337)).Apply(
+    i => Console.WriteLine(i.ToString()),
+    () => Console.WriteLine("no value"),
+    exception => Console.WriteLine(exception.Message));
+
+// "no value" is printed to the console
+string returnValue = Result.Success<Option<int>, Exception>(Option.None<int>()).Apply(
+    i => Console.WriteLine(i.ToString()),
+    () => Console.WriteLine("no value"),
+    exception => Console.WriteLine(exception.Message));
+
+// "ERROR" is printed to the console
+string returnValue = Result.Failure<Option<int>, Exception>(new Exception("ERROR")).Apply(
+    i => Console.WriteLine(i.ToString()),
+    () => Console.WriteLine("no value"),
+    exception => Console.WriteLine(exception.Message));
+)
+```
+
 ## Working with `Option<Result<TSuccess, TFailure>>`
 
 `Option<Result<TSuccess, TFailure>>` types can use all extension methods listed [for Options](option.md#working-with-optiontvalue), but some operations are easier to perform using the extension methods listed below.


### PR DESCRIPTION
Instead of this...
``` csharp
// "1337" is printed to the console
string returnValue = Result.Success<Option<int>, Exception>(Option.Some(1337)).Apply(
    option => option.Apply(i => Console.WriteLine(i.ToString()), () => Console.WriteLine("no value")),
    exception => Console.WriteLine(exception.Message));

// "no value" is printed to the console
string returnValue = Result.Success<Option<int>, Exception>(Option.None<int>()).Apply(
    option => option.Apply(i => Console.WriteLine(i.ToString()), () => Console.WriteLine("no value")),
    exception => Console.WriteLine(exception.Message));

// "ERROR" is printed to the console
string returnValue = Result.Failure<Option<int>, Exception>(new Exception("ERROR")).Apply(
    option => option.Apply(i => Console.WriteLine(i.ToString()), () => Console.WriteLine("no value")),
    exception => Console.WriteLine(exception.Message));
```

... can use the new `Apply` overload instead.
``` csharp
// "1337" is printed to the console
string returnValue = Result.Success<Option<int>, Exception>(Option.Some(1337)).Apply(
    i => Console.WriteLine(i.ToString()),
    () => Console.WriteLine("no value"),
    exception => Console.WriteLine(exception.Message));

// "no value" is printed to the console
string returnValue = Result.Success<Option<int>, Exception>(Option.None<int>()).Apply(
    i => Console.WriteLine(i.ToString()),
    () => Console.WriteLine("no value"),
    exception => Console.WriteLine(exception.Message));

// "ERROR" is printed to the console
string returnValue = Result.Failure<Option<int>, Exception>(new Exception("ERROR")).Apply(
    i => Console.WriteLine(i.ToString()),
    () => Console.WriteLine("no value"),
    exception => Console.WriteLine(exception.Message));
)
```