### PR TITLE
deprecate `ToResult`; use `ToFailureResult` instead, add `ToSuccessResult`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Authors>Johannes Moersch + contributors</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © 2020 Johannes Moersch</Copyright>
-    <Version>2.10.0</Version>
+    <Version>2.11.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/Functional.Primitives.Extensions/ObsoleteOptionExtensions.cs
+++ b/Functional.Primitives.Extensions/ObsoleteOptionExtensions.cs
@@ -49,6 +49,16 @@ namespace Functional
 		public static async Task<TValue?> ValueOrNull<TValue>(this Task<Option<TValue>> option)
 			where TValue : struct
 			=> (await option).ValueOrNull();
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("Please use .ToFailureResult() instead.")]
+		public static Result<TValue, TFailure> ToResult<TValue, TFailure>(this Option<TValue> option, Func<TFailure> failureFactory)
+			=> option.ToFailureResult(failureFactory);
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("Please use .ToFailureResult() instead.")]
+		public static async Task<Result<TValue, TFailure>> ToResult<TValue, TFailure>(this Task<Option<TValue>> option, Func<TFailure> failureFactory)
+			=> (await option).ToFailureResult(failureFactory);
 	}
 
 	public static partial class OptionAsyncExtensions
@@ -82,5 +92,15 @@ namespace Functional
 		[Obsolete("Please also handle none explicitly.")]
 		public static Task ApplyAsync<TValue>(this Task<Option<TValue>> option, Func<TValue, Task> apply)
 			=> option.DoAsync(apply);
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("Please use .ToFailureResultAsync() instead.")]
+		public static async Task<Result<TValue, TFailure>> ToResultAsync<TValue, TFailure>(this Option<TValue> option, Func<Task<TFailure>> failureFactory)
+			=> await option.ToFailureResultAsync(failureFactory);
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("Please use .ToFailureResultAsync() instead.")]
+		public static async Task<Result<TValue, TFailure>> ToResultAsync<TValue, TFailure>(this Task<Option<TValue>> option, Func<Task<TFailure>> failureFactory)
+			=> await (await option).ToFailureResultAsync(failureFactory);
 	}
 }

--- a/Functional.Primitives.Extensions/OptionAsyncExtensions.cs
+++ b/Functional.Primitives.Extensions/OptionAsyncExtensions.cs
@@ -63,7 +63,7 @@ namespace Functional
 		public static async Task<Option<TValue>> WhereAsync<TValue>(this Task<Option<TValue>> option, Func<TValue, Task<bool>> predicate)
 			=> await (await option).WhereAsync(predicate);
 
-		public static async Task<Result<TValue, TFailure>> ToResultAsync<TValue, TFailure>(this Option<TValue> option, Func<Task<TFailure>> failureFactory)
+		public static async Task<Result<TValue, TFailure>> ToFailureResultAsync<TValue, TFailure>(this Option<TValue> option, Func<Task<TFailure>> failureFactory)
 		{
 			if (failureFactory == null)
 				throw new ArgumentNullException(nameof(failureFactory));
@@ -74,8 +74,8 @@ namespace Functional
 			return Result.Failure<TValue, TFailure>(await failureFactory.Invoke());
 		}
 
-		public static async Task<Result<TValue, TFailure>> ToResultAsync<TValue, TFailure>(this Task<Option<TValue>> option, Func<Task<TFailure>> failureFactory)
-			=> await (await option).ToResultAsync(failureFactory);
+		public static async Task<Result<TValue, TFailure>> ToFailureResultAsync<TValue, TFailure>(this Task<Option<TValue>> option, Func<Task<TFailure>> failureFactory)
+			=> await (await option).ToFailureResultAsync(failureFactory);
 
 		public static async Task<Option<TValue>> DoAsync<TValue>(this Option<TValue> option, Func<TValue, Task> doWhenSome, Func<Task> doWhenNone)
 		{

--- a/Functional.Primitives.Extensions/OptionExtensions.cs
+++ b/Functional.Primitives.Extensions/OptionExtensions.cs
@@ -96,7 +96,13 @@ namespace Functional
 			where TValue : struct
 			=> (await option).ToNullable();
 
-		public static Result<TValue, TFailure> ToResult<TValue, TFailure>(this Option<TValue> option, Func<TFailure> failureFactory)
+		public static Result<Option<TValue>, TFailure> ToSuccessResult<TValue, TFailure>(this Option<TValue> option)
+			=> Result.Success<Option<TValue>, TFailure>(option);
+
+		public static async Task<Result<Option<TValue>, TFailure>> ToSuccessResult<TValue, TFailure>(this Task<Option<TValue>> option)
+			=> (await option).ToSuccessResult<TValue, TFailure>();
+
+		public static Result<TValue, TFailure> ToFailureResult<TValue, TFailure>(this Option<TValue> option, Func<TFailure> failureFactory)
 		{
 			if (failureFactory == null)
 				throw new ArgumentNullException(nameof(failureFactory));
@@ -107,8 +113,8 @@ namespace Functional
 			return Result.Failure<TValue, TFailure>(failureFactory.Invoke());
 		}
 
-		public static async Task<Result<TValue, TFailure>> ToResult<TValue, TFailure>(this Task<Option<TValue>> option, Func<TFailure> failureFactory)
-			=> (await option).ToResult(failureFactory);
+		public static async Task<Result<TValue, TFailure>> ToFailureResult<TValue, TFailure>(this Task<Option<TValue>> option, Func<TFailure> failureFactory)
+			=> (await option).ToFailureResult(failureFactory);
 
 		public static Option<TValue> Do<TValue>(this Option<TValue> option, Action<TValue> doWhenSome, Action doWhenNone)
 		{

--- a/Functional.Tests/Options/OptionAsyncExtensionsTests.cs
+++ b/Functional.Tests/Options/OptionAsyncExtensionsTests.cs
@@ -65,9 +65,9 @@ namespace Functional.Tests.Options
 					.AssertNone();
 
 			[Fact]
-			public Task ToResult()
+			public Task ToFailureResult()
 				=> Value
-					.ToResultAsync(() => Task.FromResult("abc"))
+					.ToFailureResultAsync(() => Task.FromResult("abc"))
 					.AssertSuccess()
 					.Should()
 					.Be(10);
@@ -157,9 +157,9 @@ namespace Functional.Tests.Options
 					.AssertNone();
 
 			[Fact]
-			public Task ToResult()
+			public Task ToFailureResult()
 				=> Value
-					.ToResultAsync(() => Task.FromResult("abc"))
+					.ToFailureResultAsync(() => Task.FromResult("abc"))
 					.AssertSuccess()
 					.Should()
 					.Be(10);
@@ -251,9 +251,9 @@ namespace Functional.Tests.Options
 					.AssertNone();
 
 			[Fact]
-			public Task ToResult()
+			public Task ToFailureResult()
 				=> Value
-					.ToResultAsync(() => Task.FromResult("abc"))
+					.ToFailureResultAsync(() => Task.FromResult("abc"))
 					.AssertFailure()
 					.Should()
 					.Be("abc");
@@ -337,9 +337,9 @@ namespace Functional.Tests.Options
 					.AssertNone();
 
 			[Fact]
-			public Task ToResult()
+			public Task ToFailureResult()
 				=> Value
-					.ToResultAsync(() => Task.FromResult("abc"))
+					.ToFailureResultAsync(() => Task.FromResult("abc"))
 					.AssertFailure()
 					.Should()
 					.Be("abc");

--- a/Functional.Tests/Options/OptionExtensionsTests.cs
+++ b/Functional.Tests/Options/OptionExtensionsTests.cs
@@ -102,7 +102,7 @@ namespace Functional.Tests.Options
 					.Where(i => true)
 					.AssertSome()
 					.Should()
-					.Be(10);
+					.Be(IntValue);
 
 			[Fact]
 			public void WhereFalse()
@@ -115,15 +115,24 @@ namespace Functional.Tests.Options
 				=> Value
 					.ToNullable()
 					.Should()
-					.Be(10);
+					.Be(IntValue);
 
 			[Fact]
-			public void ToResult()
+			public void ToSuccessResult()
 				=> Value
-					.ToResult(() => "abc")
+					.ToSuccessResult<int, string>()
+					.AssertSuccess()
+					.AssertSome()
+					.Should()
+					.Be(IntValue);
+
+			[Fact]
+			public void ToFailureResult()
+				=> Value
+					.ToFailureResult(() => "abc")
 					.AssertSuccess()
 					.Should()
-					.Be(10);
+					.Be(IntValue);
 
 			[Fact]
 			public void DoWithOneParameter()
@@ -271,9 +280,18 @@ namespace Functional.Tests.Options
 					.Be(IntValue);
 
 			[Fact]
-			public Task ToResult()
+			public Task ToSuccessResult()
 				=> Value
-					.ToResult(() => "abc")
+					.ToSuccessResult<int, string>()
+					.AssertSuccess()
+					.AssertSome()
+					.Should()
+					.Be(IntValue);
+
+			[Fact]
+			public Task ToFailureResult()
+				=> Value
+					.ToFailureResult(() => "abc")
 					.AssertSuccess()
 					.Should()
 					.Be(IntValue);
@@ -412,9 +430,16 @@ namespace Functional.Tests.Options
 					.BeNull();
 
 			[Fact]
-			public void ToResult()
+			public void ToSuccessResult()
 				=> Value
-					.ToResult(() => "abc")
+					.ToSuccessResult<int, string>()
+					.AssertSuccess()
+					.AssertNone();
+
+			[Fact]
+			public void ToFailureResult()
+				=> Value
+					.ToFailureResult(() => "abc")
 					.AssertFailure()
 					.Should()
 					.Be("abc");
@@ -560,9 +585,16 @@ namespace Functional.Tests.Options
 					.BeNull();
 
 			[Fact]
-			public Task ToResult()
+			public Task ToSuccessResult()
 				=> Value
-					.ToResult(() => "abc")
+					.ToSuccessResult<int, string>()
+					.AssertSuccess()
+					.AssertNone();
+
+			[Fact]
+			public Task ToFailureResult()
+				=> Value
+					.ToFailureResult(() => "abc")
 					.AssertFailure()
 					.Should()
 					.Be("abc");

--- a/Functional.Tests/Results/ResultLinqSyntaxJoinTests.cs
+++ b/Functional.Tests/Results/ResultLinqSyntaxJoinTests.cs
@@ -91,7 +91,7 @@ namespace Functional.Tests.Results
 
 		private static readonly Func<IEnumerable<(int, int)?>, IEnumerable<(int, int)>> _output = values => values.OfType<(int, int)>();
 
-		private static readonly Func<IEnumerable<(int, int)?>, IEnumerable<Result<(int, int), string>>> _resultOutput = values => values.Select(i => Option.FromNullable(i).ToResult(() => "Failure"));
+		private static readonly Func<IEnumerable<(int, int)?>, IEnumerable<Result<(int, int), string>>> _resultOutput = values => values.Select(i => Option.FromNullable(i).ToFailureResult(() => "Failure"));
 
 		[Theory]
 		[ClassData(typeof(Standard))]

--- a/doc/option.md
+++ b/doc/option.md
@@ -212,9 +212,21 @@ int value = Option.Some<int>(1337).ThrowOnNone(() => new InvalidOperationExcepti
 Option.None<int>().ThrowOnNone(() => new InvalidOperationException("Expected value!"));
 ```
 
-### ToResult
+### ToSuccessResult
 
-If `Some`, this extension will return a `Success` result with the value, and if `None` it will a `Failure` result contains the failure produced by the delegate parameter.
+This extension will return a `Success` result with the option.
+
+```csharp
+// Returns Result<Option<int>, string> with a success value of Option.Some(100)
+Result<Option<int>, string> result = Option.Some<int>(100).ToSuccessResult<int, string>();
+
+// Returns Result<Option<int>, string> with a success value of Option.None<int>()
+Result<Option<int>, string> result = Option.None<int>().ToSuccessResult<int, string>();
+```
+
+### ToFailureResult
+
+If `Some`, this extension will return a `Success` result with the value, and if `None` it will return a `Failure` result contains the failure produced by the delegate parameter.
 
 ```csharp
 // Returns Result<int, string> with a success value of 100


### PR DESCRIPTION
- adds `ToSuccessResult` method (`Option<T> => Result<Option<T>, TFailure>`); the syntax is a little awkward due to not being able to infer `TFailure` type, but it still results in less typing during method chains
- adds `ToFailureResult` method (same implementation as original `ToResult`)
- adds `ToFailureResultAsync` method (same implementation as original `ToResultAsync`)
- marked `ToResult` `Obsolete`, recommending usage of `ToFailureResult` instead
- updated documentation