### PR TITLE
add `DoOnNone` extension method to `Option<TValue>`; add `DoOnFailure` extension method to `Result<TSuccess, TFailure>`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Authors>Johannes Moersch + contributors</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © 2020 Johannes Moersch</Copyright>
-    <Version>2.11.0</Version>
+    <Version>2.12.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/Functional.Primitives.Extensions/OptionAsyncExtensions.cs
+++ b/Functional.Primitives.Extensions/OptionAsyncExtensions.cs
@@ -102,6 +102,12 @@ namespace Functional
 		public static async Task<Option<TValue>> DoAsync<TValue>(this Task<Option<TValue>> option, Func<TValue, Task> @do)
 			=> await (await option).DoAsync(@do, DelegateCache.Task);
 
+		public static async Task<Option<TValue>> DoOnNoneAsync<TValue>(this Option<TValue> option, Func<Task> @do)
+			=> await option.DoAsync(DelegateCache<TValue>.Task, @do);
+
+		public static async Task<Option<TValue>> DoOnNoneAsync<TValue>(this Task<Option<TValue>> option, Func<Task> @do)
+			=> await (await option).DoOnNoneAsync(@do);
+
 		public static Task ApplyAsync<TValue>(this Option<TValue> option, Func<TValue, Task> applyWhenSome, Func<Task> applyWhenNone)
 			=> option.DoAsync(applyWhenSome, applyWhenNone);
 

--- a/Functional.Primitives.Extensions/OptionExtensions.cs
+++ b/Functional.Primitives.Extensions/OptionExtensions.cs
@@ -135,6 +135,12 @@ namespace Functional
 		public static async Task<Option<TValue>> Do<TValue>(this Task<Option<TValue>> option, Action<TValue> @do)
 			=> (await option).Do(@do, DelegateCache.Void);
 
+		public static Option<TValue> DoOnNone<TValue>(this Option<TValue> option, Action @do)
+			=> option.Do(DelegateCache<TValue>.Void, @do);
+
+		public static async Task<Option<TValue>> DoOnNone<TValue>(this Task<Option<TValue>> option, Action @do)
+			=> (await option).DoOnNone(@do);
+
 		public static void Apply<TValue>(this Option<TValue> option, Action<TValue> applyWhenSome, Action applyWhenNone)
 			=> option.Do(applyWhenSome, applyWhenNone);
 

--- a/Functional.Primitives.Extensions/ResultAsyncExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultAsyncExtensions.cs
@@ -132,6 +132,12 @@ namespace Functional
 		public static async Task<Result<TSuccess, TFailure>> DoAsync<TSuccess, TFailure>(this Task<Result<TSuccess, TFailure>> result, Func<TSuccess, Task> success)
 			=> await (await result).DoAsync(success, DelegateCache<TFailure>.Task);
 
+		public static Task<Result<TSuccess, TFailure>> DoOnFailureAsync<TSuccess, TFailure>(this Result<TSuccess, TFailure> result, Func<TFailure, Task> failure)
+			=> result.DoAsync(DelegateCache<TSuccess>.Task, failure);
+
+		public static async Task<Result<TSuccess, TFailure>> DoOnFailureAsync<TSuccess, TFailure>(this Task<Result<TSuccess, TFailure>> result, Func<TFailure, Task> failure)
+			=> await (await result).DoAsync(DelegateCache<TSuccess>.Task, failure);
+
 		public static Task ApplyAsync<TSuccess, TFailure>(this Result<TSuccess, TFailure> result, Func<TSuccess, Task> success, Func<TFailure, Task> failure)
 			=> result.DoAsync(success, failure);
 

--- a/Functional.Primitives.Extensions/ResultExtensions.cs
+++ b/Functional.Primitives.Extensions/ResultExtensions.cs
@@ -139,6 +139,12 @@ namespace Functional
 		public static async Task<Result<TSuccess, TFailure>> Do<TSuccess, TFailure>(this Task<Result<TSuccess, TFailure>> result, Action<TSuccess> onSuccess)
 			=> (await result).Do(onSuccess);
 
+		public static Result<TSuccess, TFailure> DoOnFailure<TSuccess, TFailure>(this Result<TSuccess, TFailure> result, Action<TFailure> onFailure)
+			=> result.Do(DelegateCache<TSuccess>.Void, onFailure);
+
+		public static async Task<Result<TSuccess, TFailure>> DoOnFailure<TSuccess, TFailure>(this Task<Result<TSuccess, TFailure>> result, Action<TFailure> onFailure)
+			=> (await result).DoOnFailure(onFailure);
+
 		public static void Apply<TSuccess, TFailure>(this Result<TSuccess, TFailure> result, Action<TSuccess> onSuccess, Action<TFailure> onFailure)
 			=> result.Do(onSuccess, onFailure);
 

--- a/Functional.Tests/Options/OptionAsyncExtensionsTests.cs
+++ b/Functional.Tests/Options/OptionAsyncExtensionsTests.cs
@@ -96,6 +96,16 @@ namespace Functional.Tests.Options
 			}
 
 			[Fact]
+			public async Task DoOnNone()
+			{
+				bool none = false;
+				await Value.DoOnNoneAsync(() => Task.FromResult(none = true));
+				none
+					.Should()
+					.BeFalse();
+			}
+
+			[Fact]
 			public async Task Apply()
 			{
 				bool some = false, none = false;
@@ -182,6 +192,16 @@ namespace Functional.Tests.Options
 				some
 					.Should()
 					.BeTrue();
+				none
+					.Should()
+					.BeFalse();
+			}
+
+			[Fact]
+			public async Task DoOnNone()
+			{
+				bool none = false;
+				await Value.DoOnNoneAsync(() => Task.FromResult(none = true));
 				none
 					.Should()
 					.BeFalse();
@@ -282,6 +302,16 @@ namespace Functional.Tests.Options
 			}
 
 			[Fact]
+			public async Task DoOnNone()
+			{
+				bool none = false;
+				await Value.DoOnNoneAsync(() => Task.FromResult(none = true));
+				none
+					.Should()
+					.BeTrue();
+			}
+
+			[Fact]
 			public async Task Apply()
 			{
 				bool some = false, none = false;
@@ -362,6 +392,16 @@ namespace Functional.Tests.Options
 				some
 					.Should()
 					.BeFalse();
+				none
+					.Should()
+					.BeTrue();
+			}
+
+			[Fact]
+			public async Task DoOnNone()
+			{
+				bool none = false;
+				await Value.DoOnNoneAsync(() => Task.FromResult(none = true));
 				none
 					.Should()
 					.BeTrue();

--- a/Functional.Tests/Options/OptionExtensionsTests.cs
+++ b/Functional.Tests/Options/OptionExtensionsTests.cs
@@ -149,6 +149,16 @@ namespace Functional.Tests.Options
 			}
 
 			[Fact]
+			public void DoOnNone()
+			{
+				bool none = false;
+				Value.DoOnNone(() => none = true);
+				none
+					.Should()
+					.BeFalse();
+			}
+
+			[Fact]
 			public void Apply()
 			{
 				bool some = false, none = false;
@@ -302,6 +312,16 @@ namespace Functional.Tests.Options
 			}
 
 			[Fact]
+			public async Task DoOnNone()
+			{
+				bool none = false;
+				await Value.DoOnNone(() => none = true);
+				none
+					.Should()
+					.BeFalse();
+			}
+
+			[Fact]
 			public async Task Apply()
 			{
 				bool some = false, none = false;
@@ -437,6 +457,16 @@ namespace Functional.Tests.Options
 				some
 					.Should()
 					.BeFalse();
+				none
+					.Should()
+					.BeTrue();
+			}
+
+			[Fact]
+			public void DoOnNone()
+			{
+				bool none = false;
+				Value.DoOnNone(() => none = true);
 				none
 					.Should()
 					.BeTrue();
@@ -585,6 +615,16 @@ namespace Functional.Tests.Options
 				some
 					.Should()
 					.BeFalse();
+				none
+					.Should()
+					.BeTrue();
+			}
+
+			[Fact]
+			public async Task DoOnNone()
+			{
+				bool none = false;
+				await Value.DoOnNone(() => none = true);
 				none
 					.Should()
 					.BeTrue();

--- a/Functional.Tests/Results/ResultAsyncExtensionsTests.cs
+++ b/Functional.Tests/Results/ResultAsyncExtensionsTests.cs
@@ -103,6 +103,16 @@ namespace Functional.Tests.Results
 			}
 
 			[Fact]
+			public async Task DoOnFailure()
+			{
+				bool failure = false;
+				await Value.DoOnFailureAsync(_ => Task.FromResult(failure = true));
+				failure
+					.Should()
+					.BeFalse();
+			}
+
+			[Fact]
 			public async Task Apply()
 			{
 				bool success = false, failure = false;
@@ -236,6 +246,16 @@ namespace Functional.Tests.Results
 				success
 					.Should()
 					.BeTrue();
+				failure
+					.Should()
+					.BeFalse();
+			}
+
+			[Fact]
+			public async Task DoOnFailure()
+			{
+				bool failure = false;
+				await Value.DoOnFailureAsync(_ => Task.FromResult(failure = true));
 				failure
 					.Should()
 					.BeFalse();
@@ -385,6 +405,16 @@ namespace Functional.Tests.Results
 			}
 
 			[Fact]
+			public async Task DoOnFailure()
+			{
+				bool failure = false;
+				await Value.DoOnFailureAsync(_ => Task.FromResult(failure = true));
+				failure
+					.Should()
+					.BeTrue();
+			}
+
+			[Fact]
 			public async Task Apply()
 			{
 				bool success = false, failure = false;
@@ -518,6 +548,16 @@ namespace Functional.Tests.Results
 				success
 					.Should()
 					.BeFalse();
+				failure
+					.Should()
+					.BeTrue();
+			}
+
+			[Fact]
+			public async Task DoOnFailure()
+			{
+				bool failure = false;
+				await Value.DoOnFailureAsync(_ => Task.FromResult(failure = true));
 				failure
 					.Should()
 					.BeTrue();

--- a/Functional.Tests/Results/ResultExtensionsTests.cs
+++ b/Functional.Tests/Results/ResultExtensionsTests.cs
@@ -124,6 +124,16 @@ namespace Functional.Tests.Results
 			}
 
 			[Fact]
+			public void DoOnFailure()
+			{
+				bool failure = false;
+				Value.DoOnFailure(_ => failure = true);
+				failure
+					.Should()
+					.BeFalse();
+			}
+
+			[Fact]
 			public void Apply()
 			{
 				bool success = false, failure = false;
@@ -283,6 +293,16 @@ namespace Functional.Tests.Results
 				success
 					.Should()
 					.BeTrue();
+				failure
+					.Should()
+					.BeFalse();
+			}
+
+			[Fact]
+			public async Task DoOnFailure()
+			{
+				bool failure = false;
+				await Value.DoOnFailure(_ => failure = true);
 				failure
 					.Should()
 					.BeFalse();
@@ -458,6 +478,16 @@ namespace Functional.Tests.Results
 			}
 
 			[Fact]
+			public void DoOnFailure()
+			{
+				bool failure = false;
+				Value.DoOnFailure(_ => failure = true);
+				failure
+					.Should()
+					.BeTrue();
+			}
+
+			[Fact]
 			public void Apply()
 			{
 				bool success = false, failure = false;
@@ -627,6 +657,16 @@ namespace Functional.Tests.Results
 				success
 					.Should()
 					.BeFalse();
+				failure
+					.Should()
+					.BeTrue();
+			}
+
+			[Fact]
+			public async Task DoOnFailure()
+			{
+				bool failure = false;
+				await Value.DoOnFailure(_ => failure = true);
 				failure
 					.Should()
 					.BeTrue();

--- a/doc/option.md
+++ b/doc/option.md
@@ -185,6 +185,18 @@ Option<int> option = Option.None<int>().Do(v => Console.WriteLine(v));
 Option<int> option = Option.None<int>().Do(v => Console.WriteLine(v), () => Console.WriteLine("None"));
 ```
 
+### DoOnNone
+
+This extension returns the input `Option` and is meant only to create side effects. If `Some`, this extension will do nothing, and if `None` it will invoke the delegate parameter.
+
+``` csharp
+// Returns Option<int> with a value of 100
+Option<int> option = Option.Some(100).DoOnNone(() => Console.WriteLine("NOTHING"));
+
+// Outputs "NOTHING" to the console and returns Option<int> with no value
+Option<int> option = Option.None<int>().DoOnNone(() => Console.WriteLine("NOTHING"));
+```
+
 ### Apply
 
 This extension returns void and is meant only to create side effects. If `Some`, this extension will invoke the first delegate parameter, and if `None` it will invoke the second delegate parameter (if provided).

--- a/doc/result.md
+++ b/doc/result.md
@@ -203,16 +203,16 @@ Result<int, string> result = Result.Success<int, string>(100).Where(s => false, 
 Result<int, string> result = Result.Failure<int, string>("Failure").Where(s => true, s => $"Failed on value {v}");
 ```
 
-### MapFailure
+### MapOnFailure
 
 If `Success`, this extension will return a `Success` Result with the existing success value, and if `Failure` it will return a `Failure` Result with the value produced by the delegate parameter.
 
 ```csharp
 // Returns Result<int, int> with a success value of 100
-Result<int, int> result = Result.Success<int, string>(100).MapFailure(f => f.Length);
+Result<int, int> result = Result.Success<int, string>(100).MapOnFailure(f => f.Length);
 
 // Returns Result<int, int> with a failure value of 7
-Result<int, int> result = Result.Failure<int, string>("Failure").MapFailure(f => f.Length);
+Result<int, int> result = Result.Failure<int, string>("Failure").MapOnFailure(f => f.Length);
 ```
 
 ### Do
@@ -228,6 +228,16 @@ Result<int, string> result = Result.Failure<int, string>("Failure").Do(s => Cons
 
 // Outputs "Failure" to the console and returns Result<int, string> with a failure value of "Failure"
 Result<int, string> result = Result.Failure<int, string>("Failure").Do(s => Console.WriteLine(s), f => Console.WriteLine(f));
+```
+
+## DoOnFailure
+
+```csharp
+// Returns Result<int, string> with a success value of 100
+Result<int, string> result = Result.Success<int, string>(100).DoOnFailure(message => Console.WriteLine(message));
+
+// Outputs "Failure" to the console and returns Result<int, string> with a failure value of "Failure"
+Result<int, string> result = Result.Failure<int, string>("Failure").DoOnFailure(message => Console.WriteLine(message));
 ```
 
 ### Apply


### PR DESCRIPTION
Added `DoOnFailure` extension method to `Result<TSuccess, TFailure>`
Also updated the `result.md` document to use `MapOnFailure` instead of `MapFailure` (`MapFailure` is marked `Obsolete`)